### PR TITLE
Fix #112 added local/**/*.sh.jinja execution

### DIFF
--- a/rsconf/component/__init__.py
+++ b/rsconf/component/__init__.py
@@ -34,6 +34,17 @@ class T(PKDict):
     def append_root_bash(self, *line):
         self._root_bash.extend(line)
 
+    def append_root_bash_with_file(self, abs_path, j2_ctx):
+        """Append lines from jinja-rendered path
+
+        Distinct from `append_root_bash_with_resource`.
+
+        Args:
+            abs_path (py.path): absolute path of file to render
+            j2_ctx (PKDict): dictionary to render
+        """
+        self._root_bash.append(self._render_file(abs_path, j2_ctx))
+
     def append_root_bash_with_main(self, j2_ctx):
         self.append_root_bash_with_resource(
             '{}/main.sh'.format(self.name),
@@ -292,18 +303,23 @@ class T(PKDict):
         self._bash_append(host_path, md5=md5)
         return dst
 
+    def _render_file(self, path, j2_ctx):
+        from pykern import pkjinja
+
+        try:
+            return pkjinja.render_file(path, j2_ctx, strict_undefined=True)
+        except Exception as e:
+            pkdlog('path={} exception={}', path, e)
+            raise
+
     def _render_resource(self, name, j2_ctx):
         from pykern import pkjinja
         from rsconf import db
-        try:
-            return pkjinja.render_file(
-                db.resource_path(j2_ctx, name + pkjinja.RESOURCE_SUFFIX),
-                j2_ctx,
-                strict_undefined=True,
-            )
-        except Exception as e:
-            pkdlog('{}: {}', name, e)
-            raise
+
+        return self._render_file(
+            db.resource_path(j2_ctx, name + pkjinja.RESOURCE_SUFFIX),
+            j2_ctx,
+        )
 
     def _write_binary(self, path, data):
         """Write as binary to Linux file

--- a/rsconf/component/base_os.py
+++ b/rsconf/component/base_os.py
@@ -63,6 +63,9 @@ class T(component.T):
         #  we will want to have local files for.
         for t in sorted(values.keys()):
             s = values[t]
+            if s.basename.endswith('.sh.jinja'):
+                self.append_root_bash_with_file(s, self.j2_ctx)
+                continue
             x = s.stat()
             self.install_access(
                 mode='{:o}'.format(x.mode & 0o777),

--- a/rsconf/package_data/dev/db/local/dev/000.sh.jinja
+++ b/rsconf/package_data/dev/db/local/dev/000.sh.jinja
@@ -1,0 +1,4 @@
+{% if 'docker' in rsconf_db.components %}
+install_access 700 root root
+rsconf_install_directory /etc/docker/any-dir
+{% endif %}

--- a/rsconf/pkcli/setup_dev.py
+++ b/rsconf/pkcli/setup_dev.py
@@ -73,10 +73,15 @@ def default_command():
     for f in pkio.walk_tree(dev_d):
         if str(f).endswith('~') or str(f).startswith('#'):
             continue
-        x = f.relto(dev_d)
-        dst = root_d.join(re.sub('.jinja$', '', x))
+        x = str(f.relto(dev_d))
+        if not ('local/' in x and x.endswith('.sh.jinja')):
+            x = re.sub('.jinja$', '', x)
+        dst = root_d.join(x)
         pkio.mkdir_parent_only(dst)
-        pkjinja.render_file(f, j2_ctx, output=dst, strict_undefined=True)
+        if f.basename == dst.basename:
+            f.copy(dst)
+        else:
+            pkjinja.render_file(f, j2_ctx, output=dst, strict_undefined=True)
     rpm_d = pkio.py_path(root_d.dirname).join('rpm')
     pkio.mkdir_parent(rpm_d)
     root_d.join('rpm').mksymlinkto(rpm_d, absolute=False)


### PR DESCRIPTION
If there's a file in local ending with .sh.jinja, it will
be run through jinja via base_os and added to base_os's main
before other main commands.