### PR TITLE
Fix radiasoft/sirepo#2667. rsconf for the sirepo async tester.

### DIFF
--- a/rsconf/component/sirepo_test_http.py
+++ b/rsconf/component/sirepo_test_http.py
@@ -15,8 +15,6 @@ class T(component.T):
         from rsconf import systemd
         from rsconf.component import docker_registry
 
-        self.buildt.require_component('sirepo')
-
         j2_ctx = self.hdb.j2_ctx_copy()
         z = j2_ctx.sirepo_test_http
         systemd.timer_prepare(self, j2_ctx, on_calendar=z.on_calendar)
@@ -25,8 +23,8 @@ class T(component.T):
             image=docker_registry.absolute_image(j2_ctx, j2_ctx.sirepo.docker_image),
             j2_ctx=j2_ctx,
             env=pkcollections.PKDict(
-                SIREPO_PKCLI_TEST_HTTP_SERVER_URI=f'http://{j2_ctx.sirepo.vhost}',
+                SIREPO_PKCLI_TEST_HTTP_SERVER_URI=f'https://{j2_ctx.sirepo.vhost}',
             ),
             run_u=j2_ctx.rsconf_db.run_u,
-            cmd='sirepo test_http test',
+            cmd='sirepo test_http',
         )

--- a/rsconf/component/sirepo_test_http.py
+++ b/rsconf/component/sirepo_test_http.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+u"""Timer to run sirepo test_http
+
+:copyright: Copyright (c) 2018 Bivio Software, Inc.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+from pykern import pkcollections
+from pykern.pkdebug import pkdp
+from rsconf import component
+
+
+class T(component.T):
+    def internal_build(self):
+        from rsconf import systemd
+        from rsconf.component import docker_registry
+
+        self.buildt.require_component('sirepo')
+
+        j2_ctx = self.hdb.j2_ctx_copy()
+        z = j2_ctx.sirepo_test_http
+        systemd.timer_prepare(self, j2_ctx, on_calendar=z.on_calendar)
+        systemd.docker_unit_enable(
+            self,
+            image=docker_registry.absolute_image(j2_ctx, j2_ctx.sirepo.docker_image),
+            j2_ctx=j2_ctx,
+            env=pkcollections.PKDict(
+                SIREPO_PKCLI_TEST_HTTP_SERVER_URI=f'http://{j2_ctx.sirepo.vhost}',
+            ),
+            run_u=j2_ctx.rsconf_db.run_u,
+            cmd='sirepo test_http test',
+        )


### PR DESCRIPTION
@robnagler this is the rsconf for the sirepo test_http timer. You'll neeed to configure `on_calendar`.