### PR TITLE
Leave containers running on hub shutdown

### DIFF
--- a/rsconf/package_data/jupyterhub/conf.py.jinja
+++ b/rsconf/package_data/jupyterhub/conf.py.jinja
@@ -40,7 +40,6 @@ c.DockerSpawner.http_timeout = {{ jupyterhub.http_timeout }}
 # https://github.com/radiasoft/rsconf/issues/54
 c.DockerSpawner.image_whitelist = []
 c.DockerSpawner.image = '{{ jupyterhub.jupyter_docker_image }}'
-c.DockerSpawner.remove = True
 c.DockerSpawner.use_internal_ip = True
 c.DockerSpawner.network_name = 'host'
 c.RSDockerSpawner.cfg = '''{{ jupyterhub.rsdockerspawner_cfg }}'''


### PR DESCRIPTION
We've had issues related to conflicting containers and request going to the wrong container (https://github.com/radiasoft/rsdockerspawner/issues/19, https://github.com/radiasoft/rsdockerspawner/issues/18, https://github.com/radiasoft/rsdockerspawner/issues/12, and possibly https://github.com/radiasoft/rsdockerspawner/issues/20). Removing this value (default is False) means that jupyterhub won't try to clean up containers on shutdown which didn't appear to be working and we'd like containers to persist in between restarts of the service.