### PR TITLE
Fix #126. Running jupyterhub under Sirepo.

### DIFF
--- a/rsconf/component/nginx.py
+++ b/rsconf/component/nginx.py
@@ -53,7 +53,7 @@ def install_auth(compt, filename, host_path, visibility, j2_ctx):
     )
 
 
-def install_vhost(compt, vhost, backend_host=None, backend_port=None, resource_d=None, j2_ctx=None, listen_any=False):
+def install_vhost(compt, vhost, backend_host=None, backend_port=None, resource_d=None, j2_ctx=None, listen_any=False, nginx_kwargs=None):
     update_j2_ctx_and_install_access(compt, j2_ctx)
     kc = compt.install_tls_key_and_crt(vhost, CONF_D)
     j2_ctx.setdefault('nginx', pkcollections.Dict()).update(
@@ -63,6 +63,7 @@ def install_vhost(compt, vhost, backend_host=None, backend_port=None, resource_d
         listen_ip='0.0.0.0' if listen_any else vhost,
         backend_host=backend_host,
         backend_port=backend_port,
+        **(nginx_kwargs or pkcollections.PKDict())
     )
     compt.install_resource(
         (resource_d or compt.name) + '/nginx.conf',

--- a/rsconf/component/sirepo.py
+++ b/rsconf/component/sirepo.py
@@ -187,6 +187,9 @@ class T(component.T):
             self.install_directory(p.join(c))
         self.install_access(mode='400')
         for c in z.feature_config.proprietary_sim_types:
+            # TODO(e-carlin): Need a better way to configure this
+            if c == 'jupyterhublogin':
+                continue
             self.install_abspath(
                 self.rpm_file(jc, f'{_RPM_PREFIX}{c}'),
                 p.join(c, c + '.rpm'),

--- a/rsconf/component/sirepo.py
+++ b/rsconf/component/sirepo.py
@@ -202,20 +202,8 @@ class T(component.T):
     def _jupyterhublogin(self, z):
         if not self._jupyterhublogin_enabled():
             return
-        self.buildt.require_component('jupyterhub')
-        j = self.buildt.get_component('jupyterhub')
-        d = j.jc.jupyterhub.user_d
-        self.j2_ctx_pksetdefault(dict(
-            sirepo=dict(
-                sim_api=dict(
-                    jupyterhublogin=dict(
-                        src_db_root=d,
-                        dst_db_root=d,
-                    ),
-                ),
-            ),
-        ))
-        self.__uwsgi_docker_vols.append(d)
+        # TODO(e-carlin): verify dir
+        self.__uwsgi_docker_vols.append(z.sim_api.jupyterhublogin.user_db_root)
         self._set_sirepo_config('sirepo_jupyterhub')
 
     def _jupyterhublogin_enabled(self):

--- a/rsconf/component/sirepo.py
+++ b/rsconf/component/sirepo.py
@@ -187,13 +187,11 @@ class T(component.T):
             self.install_directory(p.join(c))
         self.install_access(mode='400')
         for c in z.feature_config.proprietary_sim_types:
-            # TODO(e-carlin): Need a better way to configure this
-            if c == 'jupyterhublogin':
-                continue
-            self.install_abspath(
-                self.rpm_file(jc, f'{_RPM_PREFIX}{c}'),
-                p.join(c, c + '.rpm'),
-            )
+            if c != 'jupyterhublogin':
+                self.install_abspath(
+                    self.rpm_file(jc, f'{_RPM_PREFIX}{c}'),
+                    p.join(c, c + '.rpm'),
+                )
 
     def _jupyterhublogin(self, z):
         z.jupyterhub_enabled =  'jupyterhublogin' in self.j2_ctx.sirepo.feature_config.proprietary_sim_types

--- a/rsconf/component/sirepo.py
+++ b/rsconf/component/sirepo.py
@@ -59,7 +59,6 @@ class T(component.T):
                 feature_config=dict(
                     api_modules=[],
                     job=True,
-                    other_sim_types=tuple(),
                     proprietary_sim_types=tuple(),
                 ),
                 job=dict(
@@ -194,7 +193,7 @@ class T(component.T):
             )
 
     def _jupyterhublogin(self, z):
-        z.jupyterhub_enabled =  'jupyterhublogin' in self.j2_ctx.sirepo.feature_config.other_sim_types
+        z.jupyterhub_enabled =  'jupyterhublogin' in self.j2_ctx.sirepo.feature_config.proprietary_sim_types
         if not z.jupyterhub_enabled:
             return
         self.__uwsgi_docker_vols.append(z.sim_api.jupyterhublogin.user_db_root_d)

--- a/rsconf/component/sirepo_jupyterhub.py
+++ b/rsconf/component/sirepo_jupyterhub.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+u"""JupyterHub under Sirepo configuration
+
+:copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+from __future__ import absolute_import, division, print_function
+from pykern import pkjson
+from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdp
+from rsconf import component
+
+_COOKIE_SECRET = 'sirepo_jupyterhub_cookie_secret'
+_CONF_F = 'conf.py'
+_DEFAULT_PORT_BASE = 8100
+# POSIT: rsdockerspawner._DEFAULT_POOL_NAME
+_DEFAULT_USER_GROUP = 'everybody'
+_DEFAULT_POOL_V3 = _DEFAULT_USER_GROUP
+_DOCKER_TLS_SUBDIR = 'docker_tls'
+_PROXY_AUTH = 'sirepo_jupyterhub_proxy_auth'
+_TEMPLATE_D = 'template'
+
+
+class T(component.T):
+
+    def internal_build_compile(self):
+        from rsconf import db
+        from rsconf import systemd
+        from rsconf.component import docker_registry
+
+        self.buildt.require_component('docker')
+        jc, z = self.j2_ctx_init()
+        self.__run_d = systemd.docker_unit_prepare(self, jc)
+
+    def internal_build_write(self):
+        from rsconf import db
+        from rsconf import systemd
+        from rsconf.component import docker
+        from rsconf.component import docker_registry
+
+        def _env_ok(elem):
+            for p in (
+                    # TODO(e-carlin): all of auth and smtp is really too much.
+                    # We just need auth_methods for checking if the cookies is
+                    # valid. But bringing in methods then initializes the methods
+                    # so we have to bring in their full config.
+                    'SIREPO_AUTH',
+                    'SIREPO_COOKIE',
+                    'SIREPO_FEATURE_CONFIG_OTHER_SIM',
+                    'SIREPO_SIM_API_JUPYTERHUBLOGIN',
+                    'SIREPO_SMTP',
+                    'SIREPO_SRDB',
+            ):
+                if elem[0].startswith(f'{p}'):
+                    return True
+            return False
+
+        jc = self.j2_ctx
+        z = jc[self.name]
+        s = jc.sirepo
+        z.update(
+            user_d=s.sim_api.jupyterhublogin.dst_db_root,
+            jupyter_docker_image=docker_registry.absolute_image(
+                jc, z.jupyter_docker_image,
+            ),
+            run_u=jc.rsconf_db.run_u,
+            jupyter_run_u=jc.rsconf_db.run_u,
+        )
+        z.setdefault('http_timeout', 30);
+        z.setdefault('template_vars', {});
+        z.template_d = self.__run_d.join(_TEMPLATE_D)
+        z.home_d = db.user_home_path(jc, z.jupyter_run_u)
+        z.cookie_secret_hex = self.secret_path_value(
+            _COOKIE_SECRET,
+            gen_secret=lambda: db.random_string(length=64, is_hex=True),
+            visibility='channel',
+        )[0]
+        z.proxy_auth_token = self.secret_path_value(
+            _PROXY_AUTH,
+            gen_secret=lambda: db.random_string(length=64, is_hex=True),
+            visibility='channel',
+        )[0]
+        z.admin_users_str = _list_to_str(z.admin_users)
+        self._rsdockerspawner(jc, z)
+
+        self.install_access(mode='711', owner=z.run_u)
+        self.install_directory(self.__run_d)
+        self.install_access(mode='700', owner=z.jupyter_run_u)
+        self.install_directory(z.user_d)
+        self.install_directory(z.template_d)
+        self.install_access(mode='400', owner=z.run_u)
+        docker.setup_cluster(
+            self,
+            hosts=z.docker_hosts,
+            tls_d=z.tls_d,
+            run_u=z.run_u,
+            j2_ctx=jc,
+        )
+        s = jc.sirepo
+        conf_f = self.__run_d.join(_CONF_F)
+        self.install_resource('sirepo_jupyterhub/{}'.format(_CONF_F), jc, conf_f)
+        self.append_root_bash(
+            "rsconf_service_docker_pull '{}'".format(z.jupyter_docker_image),
+        )
+        systemd.docker_unit_enable(
+            self,
+            jc,
+            cmd="bash -l -c 'jupyterhub -f {}'".format(conf_f),
+            env=PKDict(filter(
+                _env_ok,
+                self.buildt.get_component('sirepo').sirepo_unit_env(self).items(),
+            )),
+            image=docker_registry.absolute_image(jc, z.docker_image),
+            run_u=z.run_u,
+            volumes=[
+                s.sim_api.jupyterhublogin.dst_db_root,
+                s.srdb.root,
+            ],
+        )
+
+    def sirepo_config(self, sirepo):
+        self.j2_ctx_pksetdefault(sirepo.j2_ctx)
+
+    def _rsdockerspawner(self, j2_ctx, z):
+        from rsconf.component import docker
+
+        z.tls_d = self.__run_d.join(_DOCKER_TLS_SUBDIR)
+        c = PKDict(
+            port_base=z.setdefault('port_base', _DEFAULT_PORT_BASE),
+            tls_dir=str(z.tls_d),
+        )
+        seen = PKDict(
+            hosts=PKDict(),
+            users=PKDict(),
+        )
+        # POSIT: notebook_dir in
+        # radiasoft/container-beamsim-jupyter/container-conf/build.sh
+        # parameterize anyway, because matches above
+        z.setdefault('volumes', PKDict())
+        z.volumes.setdefault(
+            str(z.user_d.join('{username}')),
+            PKDict(bind=str(z.home_d.join('jupyter'))),
+        )
+        self._rsdockerspawner_v3(j2_ctx, z, seen)
+        c.user_groups = z.get('user_groups', PKDict())
+        c.volumes = z.volumes
+        c.pools = z.pools
+        z.rsdockerspawner_cfg = pkjson.dump_pretty(c)
+        z.docker_hosts = list(seen.hosts.keys())
+
+    def _rsdockerspawner_v3(self, j2_ctx, z, seen):
+        def _users_for_groups(groups, t, n):
+            res = set()
+            for g in groups:
+                if g == _DEFAULT_USER_GROUP:
+                    return []
+                u = z.user_groups.get(g)
+                assert u is not None, \
+                    'user_group={} not found for {}={}'.format(g ,t, n)
+                res.union(u)
+            return sorted(res)
+
+        for n, v in z.volumes.items():
+            m = v.get('mode')
+            if not isinstance(m, dict):
+                continue
+            seen2 = set()
+            for g in m.values():
+                for u in _users_for_groups(g, 'volume', n):
+                    assert u not in seen2, \
+                        'user={} in both modes for volume={}'.format(u, n)
+                    seen2.add(u)
+        for n, p in z.pools.items():
+            for h in p['hosts']:
+                assert h not in seen.hosts, \
+                    'duplicate host={} in two pools {} and {}'.format(
+                        h,
+                        n,
+                        seen.hosts[h],
+                    )
+                seen.hosts[h] = n
+            if n == _DEFAULT_POOL_V3:
+                assert 'user_groups' not in p, \
+                    'user_groups may not be specified for pool={}'.format(n)
+            else:
+                for u in _users_for_groups(p.user_groups, 'pool', n):
+                    assert u not in seen.users, \
+                        'duplicate user={} in two pools {} and {}'.format(
+                            u,
+                            n,
+                            seen.hosts[u],
+                        )
+                    seen.users[s] = n
+
+
+def _list_to_str(v):
+    return "'" + "','".join(v) + "'"

--- a/rsconf/component/sirepo_jupyterhub.py
+++ b/rsconf/component/sirepo_jupyterhub.py
@@ -46,7 +46,7 @@ class T(component.T):
                     # so we have to bring in their full config.
                     'SIREPO_AUTH',
                     'SIREPO_COOKIE',
-                    'SIREPO_FEATURE_CONFIG_OTHER_SIM',
+                    'SIREPO_FEATURE_PROPRIETARY_SIM',
                     'SIREPO_SIM_API_JUPYTERHUBLOGIN',
                     'SIREPO_SMTP',
                     'SIREPO_SRDB',

--- a/rsconf/package_data/dev/db/000.yml.jinja
+++ b/rsconf/package_data/dev/db/000.yml.jinja
@@ -245,7 +245,7 @@ channel:
         mail_username: comsol@{{ host }}
         mail_password: somepass
       feature_config:
-       other_sim_types:
+       proprietary_sim_types:
          - jupyterhublogin
       sim_api:
         jupyterhublogin:

--- a/rsconf/package_data/dev/db/000.yml.jinja
+++ b/rsconf/package_data/dev/db/000.yml.jinja
@@ -64,6 +64,7 @@ default:
           on_calendar: "1 0"
           bash_script: |
             echo doing that thing
+
   btest:
     client_host: {{ worker6_host }}
     email_user: {{ user }}
@@ -245,8 +246,8 @@ channel:
         mail_username: comsol@{{ host }}
         mail_password: somepass
       feature_config:
-       proprietary_sim_types:
-         - jupyterhublogin
+        proprietary_sim_types:
+          - jupyterhublogin
       sim_api:
         jupyterhublogin:
           # POSIT: Jupyterhub user_d

--- a/rsconf/package_data/dev/db/000.yml.jinja
+++ b/rsconf/package_data/dev/db/000.yml.jinja
@@ -64,9 +64,6 @@ default:
           on_calendar: "1 0"
           bash_script: |
             echo doing that thing
-
-
-
   btest:
     client_host: {{ worker6_host }}
     email_user: {{ user }}
@@ -204,6 +201,13 @@ default:
       service_port: 7000
       job_supervisor:
         port: 7001
+  sirepo_jupyterhub:
+    admin_users: [ '{{ user }}' ]
+    docker_image: radiasoft/jupyterhub
+    jupyter_docker_image: radiasoft/beamsim-jupyter
+    port: 7914
+    configurable_http_proxy_port: 8111
+    uri_root: 'jupyter'
   spamd: {}
   systemd:
     extra_run_flags:
@@ -240,6 +244,9 @@ channel:
         mail_server: {{ host }}
         mail_username: comsol@{{ host }}
         mail_password: somepass
+      feature_config:
+       other_sim_types:
+         - jupyterhublogin
       mpi_cores: 4
       vhost: sirepo.{{ host }}
     wordpress:
@@ -357,13 +364,41 @@ host:
 
         #components: [ rsconf, docker_registry, btest ]
 #        components: [ bop ]
-        components: [ bkp, jupyterhub, jupyterhub_proxy ]
-#        components: [ nfs_server, sirepo ]
+        #components: [ bkp, jupyterhub, jupyterhub_proxy ]
+        components: [ nfs_server, sirepo, sirepo_jupyterhub ]
       sirepo:
+        auth:
+          methods:
+            - email
         job_driver:
           docker:
             dev_volumes: false
             hosts: [ {{ host }} ]
+      sirepo_jupyterhub:
+        pools:
+          everybody:
+            servers_per_host: 2
+            mem_limit: "1G"
+            cpu_limit: 0.5
+            shm_size: "256M"
+            hosts: [ {{ worker6_host }}, {{ worker5_host }} ]
+          private:
+            user_groups: [ private ]
+            servers_per_host: 1
+            hosts: [ {{ host }} ]
+        user_groups:
+          private: [ vagrant ]
+          instructors: [ teach1 ]
+        volumes:
+          /srv/jupyterhub/user/Workshop:
+            bind: /home/vagrant/jupyter/Workshop
+            mode: ro
+          /srv/jupyterhub/user/Workshop/{username}:
+            bind: /home/vagrant/jupyter/Workshop/{username}
+            mode:
+              rw: [ instructors ]
+        vhosts:
+          {{ host }}: sirepo.{{ host }}
     {{ worker5_host }}:
       docker:
         tls_host: {{ worker5_host }}
@@ -471,6 +506,7 @@ host:
           - comsol
           - sirepo
           - sirepo_job_supervisor
+          - sirepo_jupyterhub
           - sirepo_test_http
           - bop
           - btest
@@ -502,6 +538,15 @@ host:
         job_driver:
           docker:
             hosts: [ {{ all_host }} ]
+      sirepo_jupyterhub:
+        pools:
+          everybody:
+            servers_per_host: 2
+            mem_limit: "1G"
+            cpu_limit: 0.5
+            hosts: [ {{ all_host }} ]
+        vhosts:
+          {{ all_host }}: sirepo.{{ all_host }}
       sirepo_test_http:
         on_calendar: "9:00"
 

--- a/rsconf/package_data/dev/db/000.yml.jinja
+++ b/rsconf/package_data/dev/db/000.yml.jinja
@@ -247,6 +247,10 @@ channel:
       feature_config:
        other_sim_types:
          - jupyterhublogin
+      sim_api:
+        jupyterhublogin:
+          # POSIT: Jupyterhub user_d
+          user_db_root: /srv/jupyterhub/user
       mpi_cores: 4
       vhost: sirepo.{{ host }}
     wordpress:
@@ -365,7 +369,7 @@ host:
         #components: [ rsconf, docker_registry, btest ]
 #        components: [ bop ]
         #components: [ bkp, jupyterhub, jupyterhub_proxy ]
-        components: [ nfs_server, sirepo, sirepo_jupyterhub ]
+        components: [ nfs_server, sirepo ]
       sirepo:
         auth:
           methods:

--- a/rsconf/package_data/sirepo/nginx.conf.jinja
+++ b/rsconf/package_data/sirepo/nginx.conf.jinja
@@ -10,20 +10,6 @@ server {
     root {{ nginx.default_root }};
     ssl_certificate {{ nginx.tls_crt }};
     ssl_certificate_key {{ nginx.tls_key }};
-{% if 'jupyterhub_enabled' in sirepo %}
-    proxy_http_version 1.1;
-    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
-    proxy_read_timeout 600s;
-    proxy_send_timeout 600s;
-    proxy_connect_timeout 600s;
-    proxy_redirect off;
-    proxy_set_header Host $host:$server_port;
-    proxy_set_header X-Real-Ip $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_cache_bypass $http_upgrade;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-{% endif %}
 
     location / {
         allow all;
@@ -33,7 +19,7 @@ server {
         uwsgi_send_timeout 300s;
         uwsgi_pass {{ nginx.backend_host }}:{{ nginx.backend_port }};
     }
-{% if 'jupyterhub_enabled' in sirepo %}
+{% if sirepo.jupyterhub_enabled %}
     location /{{ sirepo_jupyterhub.uri_root }}/hub/logout {
         return 301 /auth-logout;
     }

--- a/rsconf/package_data/sirepo/nginx.conf.jinja
+++ b/rsconf/package_data/sirepo/nginx.conf.jinja
@@ -10,6 +10,21 @@ server {
     root {{ nginx.default_root }};
     ssl_certificate {{ nginx.tls_crt }};
     ssl_certificate_key {{ nginx.tls_key }};
+{% if 'jupyterhub_enabled' in nginx  %}
+    proxy_http_version 1.1;
+    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+    proxy_connect_timeout 600s;
+    proxy_redirect off;
+    proxy_set_header Host $host:$server_port;
+    proxy_set_header X-Real-Ip $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_cache_bypass $http_upgrade;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+{% endif %}
+
     location / {
         allow all;
         include uwsgi_params;
@@ -18,4 +33,12 @@ server {
         uwsgi_send_timeout 300s;
         uwsgi_pass {{ nginx.backend_host }}:{{ nginx.backend_port }};
     }
+{% if 'jupyterhub_enabled' in nginx  %}
+    location /{{ nginx.jupyterhub_uri_root }}/hub/logout {
+        return 301 /auth-logout;
+    }
+    location /{{ nginx.jupyterhub_uri_root }}/ {
+        proxy_pass http://127.0.0.1:{{ nginx.jupyterhub_proxy_port }};
+    }
+{% endif %}
 }

--- a/rsconf/package_data/sirepo_jupyterhub/conf.py.jinja
+++ b/rsconf/package_data/sirepo_jupyterhub/conf.py.jinja
@@ -1,0 +1,27 @@
+# -*-python-*-
+from rsdockerspawner import rsdockerspawner
+import binascii
+import jupyterhub.spawner
+import sirepo.jupyterhub
+
+
+c.Authenticator.admin_users = set([{{ sirepo_jupyterhub.admin_users_str }}])
+c.ConfigurableHTTPProxy.api_url = 'http://127.0.0.1:{{ sirepo_jupyterhub.configurable_http_proxy_port }}'
+c.ConfigurableHTTPProxy.auth_token = '{{ sirepo_jupyterhub.proxy_auth_token }}'
+c.DockerSpawner.http_timeout = {{sirepo_jupyterhub.http_timeout}}
+c.DockerSpawner.image = '{{ sirepo_jupyterhub.jupyter_docker_image }}'
+# https://github.com/radiasoft/rsconf/issues/54
+c.DockerSpawner.image_whitelist = []
+c.DockerSpawner.network_name = 'host'
+c.DockerSpawner.use_internal_ip = True
+c.JupyterHub.authenticator_class = sirepo.jupyterhub.Authenticator
+c.JupyterHub.base_url = '/{{ sirepo_jupyterhub.uri_root }}'
+c.JupyterHub.cleanup_servers = False
+c.JupyterHub.cookie_secret = binascii.a2b_hex('{{ sirepo_jupyterhub.cookie_secret_hex }}')
+c.JupyterHub.ip = '127.0.0.1'
+c.JupyterHub.port = {{ sirepo_jupyterhub.port }}
+c.JupyterHub.spawner_class = rsdockerspawner.RSDockerSpawner
+c.JupyterHub.template_paths = ['{{ sirepo_jupyterhub.template_d }}']
+c.JupyterHub.template_vars = {{ sirepo_jupyterhub.template_vars }}
+c.JupyterHub.upgrade_db = True
+c.RSDockerSpawner.cfg = '''{{ sirepo_jupyterhub.rsdockerspawner_cfg }}'''


### PR DESCRIPTION
I believe this covers everything for running jupyterhub at sirepo.com/jupyter.

For dev getting everything running on a remote server using ssh LocalForward required some hacks. There were issues with re-directs dropping the port number and jupyterhub blocking requests due to them being cross origin. In the end I setup a reverse proxy on my mac and edited /etc/hosts to make it all work. My nginx foo isn't the best so maybe there is a simpler way to get it working that doesn't require a reverse proxy.

~/.ss/config on mac:

Host <redacted>
  HostName <redacted>
  Port  <redacted>
  User <redcated>
  LocalForward 8080 sirepo.v4.radia.run:443

nginx on mac:

brew install nginx
cd /usr/local/etc/nginx
sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout cert.key -out crt.pem # for fqdn use sirepo.v4.radia.run
cat <<EOF > /usr/local/etc/nginx/nginx.conf
worker_processes  1;
error_log /usr/local/var/log/nginx/error.log debug;

events {
    worker_connections  1024;
}

http {
    include       mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    sendfile        on;
    keepalive_timeout  65;

    proxy_buffer_size   128k;
    proxy_buffers   4 256k;
    proxy_busy_buffers_size   256k;
    server {
      listen 443 ssl;
      server_name sirepo.v4.radia.run;
      ssl_certificate      cert.pem;
      ssl_certificate_key  cert.key;
      proxy_http_version 1.1;
      proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
      proxy_read_timeout 600s;
      proxy_send_timeout 600s;
      proxy_connect_timeout 600s;
      proxy_redirect off;
      proxy_set_header Host $host:$server_port;
      proxy_set_header Proxy "";
      proxy_set_header Via $remote_addr;
      proxy_set_header X-Real-Ip $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header X-Forwarded-Proto $scheme;
      proxy_cache_bypass $http_upgrade;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection "upgrade";
      location / {
          proxy_pass         https://localhost:8080;
      }
    }
    include servers/*;
}
EOF
brew services start nginx

/etc/hosts on mac:
127.0.0.1 localhost localhost.localdomain sirepo.v4.radia.run

Then visit https://sirepo.v4.radia.run/jupyter in your browser.