### PR TITLE
Fix #134. Jupyterhub proxy redirect loop

### DIFF
--- a/rsconf/component/jupyterhub_proxy.py
+++ b/rsconf/component/jupyterhub_proxy.py
@@ -25,7 +25,7 @@ class T(component.T):
                 self,
                 vhost=vh,
                 backend_host=h,
-                backend_port=jc.jupyterhub.api_port,
+                backend_port=jc.jupyterhub.configurable_http_proxy_port,
                 j2_ctx=jc,
                 listen_any=jc.jupyterhub_proxy.listen_any,
             )

--- a/rsconf/package_data/dev/db/000.yml.jinja
+++ b/rsconf/package_data/dev/db/000.yml.jinja
@@ -99,6 +99,7 @@ default:
     #  client_id: ""
     #  client_secret: ""
     api_port: 7913
+    configurable_http_proxy_api_port: 8113
     configurable_http_proxy_port: 8110
     vhosts:
       {{ host }}: jupyter.{{ host }}

--- a/rsconf/package_data/jupyterhub/conf.py.jinja
+++ b/rsconf/package_data/jupyterhub/conf.py.jinja
@@ -29,6 +29,7 @@ c.JupyterHub.cleanup_servers = False
 #TODO(robnagler) DEPRECATED remove after prod release
 c.JupyterHub.confirm_no_ssl = True
 c.JupyterHub.cookie_secret = binascii.a2b_hex('{{ jupyterhub.cookie_secret_hex }}')
+c.ConfigurableHTTPProxy.api_url = 'http://{{ jupyterhub.hub_ip }}:{{ jupyterhub.configurable_http_proxy_api_port }}'
 c.JupyterHub.hub_ip = '{{ jupyterhub.hub_ip }}'
 c.JupyterHub.ip = '{{ jupyterhub.hub_ip }}'
 c.JupyterHub.port = {{ jupyterhub.configurable_http_proxy_port }}


### PR DESCRIPTION
Nginx needs to send traffic to the configurable proxy port not the hub
port.

Define the ConfigurableHTTPProxy.api_url. The default was working
before but better to be explicit.