### PR TITLE
Fix radiasoft/devops#249 use git+https:// for pip install

### DIFF
--- a/rsconf/package_data/github_bkp/run.sh.jinja
+++ b/rsconf/package_data/github_bkp/run.sh.jinja
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 # Avoid filling up log so can see output of backup more clearly
-pip --quiet --disable-pip-version-check install 'git+git://github.com/radiasoft/pykern#egg=pykern'
+pip --quiet --disable-pip-version-check install 'git+https://github.com/radiasoft/pykern#egg=pykern'
 # https://git-scm.com/docs/git-credential-store#_storage_format
 install -m 600 /dev/stdin ~/.github_bkp_creds <<EOF
 https://$PYKERN_PKCLI_GITHUB_USER:$PYKERN_PKCLI_GITHUB_PASSWORD@github.com

--- a/tests/pkcli/build_data/run/srv/host/v9.radia.run/github_bkp.sh
+++ b/tests/pkcli/build_data/run/srv/host/v9.radia.run/github_bkp.sh
@@ -14,7 +14,7 @@ rsconf_install_file '/etc/systemd/system/github_bkp.timer' 'bca46813a5c7dd3020c6
 rsconf_install_file '/etc/systemd/system/github_bkp.service' 'c4c23cec8aeb4c20d03f4a2497e5bcaf'
 rsconf_service_docker_pull 'docker.io/radiasoft/beamsim:dev' 'github_bkp'
 rsconf_install_access '500' 'vagrant' 'vagrant'
-rsconf_install_file '/srv/github_bkp/run' '25d38d30da8e138c8a79d1a7b9b673cf'
+rsconf_install_file '/srv/github_bkp/run' '27969640e856d5bed8c1fd73d29afad2'
 rsconf_install_access '700' 'vagrant' 'vagrant'
 rsconf_install_directory '/srv/github_bkp/db'
 }

--- a/tests/pkcli/build_data/run/srv/host/v9.radia.run/srv/github_bkp/run
+++ b/tests/pkcli/build_data/run/srv/host/v9.radia.run/srv/github_bkp/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 # Avoid filling up log so can see output of backup more clearly
-pip --quiet --disable-pip-version-check install 'git+git://github.com/radiasoft/pykern#egg=pykern'
+pip --quiet --disable-pip-version-check install 'git+https://github.com/radiasoft/pykern#egg=pykern'
 # https://git-scm.com/docs/git-credential-store#_storage_format
 install -m 600 /dev/stdin ~/.github_bkp_creds <<EOF
 https://$PYKERN_PKCLI_GITHUB_USER:$PYKERN_PKCLI_GITHUB_PASSWORD@github.com


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/
tl;dr github no longer allows git+git:// because it is insecure.