### PR TITLE
Fix #187: add flag for no service restart

### DIFF
--- a/rsconf/package_data/rsconf/rsconf.sh
+++ b/rsconf/package_data/rsconf/rsconf.sh
@@ -426,6 +426,9 @@ rsconf_service_prepare() {
 }
 
 rsconf_service_restart() {
+    if [[ ${rsconf_service_no_restart:-} ]]; then
+        return
+    fi
     local s
     # Always reload at start. Just easier and more reliable
     systemctl daemon-reload


### PR DESCRIPTION
Can be run with `rsconf_service_no_restart rsc`. This allows one to change
the configuration on the machine but manually control when the service is
restarted.