### PR TITLE
WIP radiasoft/download#233: env comes from env_keep

### DIFF
--- a/rsconf/package_data/jupyterhub/conf.py.jinja
+++ b/rsconf/package_data/jupyterhub/conf.py.jinja
@@ -42,6 +42,19 @@ c.RSDockerSpawner.cfg = '''{{ jupyterhub.rsdockerspawner_cfg }}'''
 c.JupyterHub.spawner_class = rsdockerspawner.RSDockerSpawner
 if hasattr(rsdockerspawner.RSDockerSpawner, 'sirepo_template_dir'):
     c.JupyterHub.template_paths = [rsdockerspawner.RSDockerSpawner.sirepo_template_dir()]
+# Relevant default values from jupyter
+# https://github.com/jupyterhub/jupyterhub/blob/909b3ad4d708a7369343c8a8537c95c05aae3b67/jupyterhub/spawner.py#L433
+# In addition, values specific for our environment
+c.Spawner.env_keep = [
+    'JUPYTERHUB_SINGLEUSER_APP',
+    'LANG',
+    'LC_ALL',
+    'LD_LIBRARY_PATH',
+    'PATH',
+    'PKG_CONFIG_PATH'
+    'PYTHONPATH',
+    'VIRTUAL_ENV',
+]
 #c.Application.log_level = 'DEBUG'
 # Might not want this, but for now it's useful to see everything
 #c.JupyterHub.debug_db = True

--- a/rsconf/package_data/sirepo_jupyterhub/conf.py.jinja
+++ b/rsconf/package_data/sirepo_jupyterhub/conf.py.jinja
@@ -42,3 +42,16 @@ if hasattr(rsdockerspawner.RSDockerSpawner, 'sirepo_template_dir'):
 c.JupyterHub.template_vars = {{ sirepo_jupyterhub.template_vars }}
 c.JupyterHub.upgrade_db = True
 c.RSDockerSpawner.cfg = '''{{ sirepo_jupyterhub.rsdockerspawner_cfg }}'''
+# Relevant default values from jupyter
+# https://github.com/jupyterhub/jupyterhub/blob/909b3ad4d708a7369343c8a8537c95c05aae3b67/jupyterhub/spawner.py#L433
+# In addition, values specific for our environment
+c.Spawner.env_keep = [
+    'JUPYTERHUB_SINGLEUSER_APP',
+    'LANG',
+    'LC_ALL',
+    'LD_LIBRARY_PATH',
+    'PATH',
+    'PKG_CONFIG_PATH'
+    'PYTHONPATH',
+    'VIRTUAL_ENV',
+]


### PR DESCRIPTION
Previously, env was hardcoded in the kernel.json (set at build time).
This doesn't work because some values (ex LD_LIBRARY_PATH) are only
known at runtime.

Unfortunately, jupyterhub doesn't allow for augmenting of the default env_keep
values. Some of them are required for the notebook to work so, they are copied
here and augmented.