### PR TITLE
Fix #209: add selectable jupyterhub authenticator

### DIFF
--- a/rsconf/component/sirepo.py
+++ b/rsconf/component/sirepo.py
@@ -197,14 +197,9 @@ class T(component.T):
             )
 
     def _jupyterhublogin(self, z):
-        p = set(self.j2_ctx.sirepo.feature_config.get('default_proprietary_sim_types', []))
-        m = set(self.j2_ctx.sirepo.feature_config.get('moderated_sim_types', []))
-        z.using_moderated_sim_types = True
-        if 'jupyterhublogin' in p:
-            assert not m, \
-                f'can only set one of default_proprietary_sim_types={p} or moderated_sim_types={m}'
-            z.using_moderated_sim_types = False
-        z.jupyterhub_enabled =  'jupyterhublogin' in p.union(m)
+        z.jupyterhub_enabled =  'jupyterhublogin' in set(
+            self.j2_ctx.sirepo.feature_config.get('default_proprietary_sim_types', []),
+        ).union(set(self.j2_ctx.sirepo.feature_config.get('moderated_sim_types', [])))
         if not z.jupyterhub_enabled:
             return
         self.__uwsgi_docker_vols.append(z.sim_api.jupyterhublogin.user_db_root_d)

--- a/rsconf/package_data/sirepo_jupyterhub/conf.py.jinja
+++ b/rsconf/package_data/sirepo_jupyterhub/conf.py.jinja
@@ -26,7 +26,7 @@ c.DockerSpawner.image = '{{ sirepo_jupyterhub.jupyter_docker_image }}'
 c.DockerSpawner.image_whitelist = []
 c.DockerSpawner.network_name = 'host'
 c.DockerSpawner.use_internal_ip = True
-{% if sirepo.using_moderated_sim_types %}
+{% if not sirepo_jupyterhub.get('use_authenticator') %}
 c.JupyterHub.authenticator_class = sirepo.jupyterhub.SirepoAuthenticator
 c.SirepoAuthenticator.sirepo_uri = '{{ sirepo_jupyterhub.sirepo_uri }}'
 {% else %}


### PR DESCRIPTION
There was a bug in an update to the sirepo jupyterhub authenticator
 (original change: git.radiasoft.org/sirepo/pull/4211 subsequent bug: git.radiasoft.org/sirepo/issues/4583).
In order to roll back the change we wanted to try making jupyterhublogin a default_proprietary_sim_type
again. But, that forced the use of the old authenticator class (`sirepo.jupyterhub.Authenticator`) which
doesn't exist in the latest image. So, add this configuration so we can say which authenticator
we want regardless of which sim type jupyterhublogin is.