### PR TITLE
Fix #250: add ability to restrict ports

### DIFF
--- a/rsconf/component/network.py
+++ b/rsconf/component/network.py
@@ -43,6 +43,7 @@ class T(component.T):
         self.j2_ctx = self.hdb.j2_ctx_copy()
         jc = self.j2_ctx
         z = jc.network
+        self._check_restricted_ports(z)
         z.trusted_nets = tuple(sorted(z.trusted.keys()))
         z.pksetdefault(
             blocked_ips=[],
@@ -150,6 +151,19 @@ class T(component.T):
             for w in check:
                 assert not p in z[w], "port {} already in {}".format(p, w)
             z[which].append(p)
+
+    def _check_restricted_ports(self, z):
+        if "restrict_ports" not in z:
+            return
+        assert (
+            "443" not in z.restrict_ports
+        ), f"use https instead of 443 in restrict_ports={z.restrict_ports}"
+        assert (
+            "http" not in z.restrict_ports and "80" not in z.restrict_ports
+        ), f"only define https not http or 80 in restrict_ports={z.restrict_ports}"
+        if "https" not in z.restrict_ports:
+            return
+        z.restrict_ports["http"] = z.restrict_ports.https
 
     def _defroute(self, routes):
         defroute = None

--- a/rsconf/component/network.py
+++ b/rsconf/component/network.py
@@ -100,6 +100,8 @@ class T(rsconf.component.T):
         jc = self.j2_ctx
         jc = self.j2_ctx
         z = jc.network
+        # Order matters: _restricted_public_tcp_ports modifed public_tcp_ports
+        # to remove ports that that in the restricted set.
         self._restricted_public_tcp_ports(z)
         if not "_devs" in z:
             # no devices, no network config

--- a/rsconf/component/network.py
+++ b/rsconf/component/network.py
@@ -1,19 +1,18 @@
-# -*- coding: utf-8 -*-
 """create network config
 
 We disable NetworkManager, because we are managing the network now.
 It's unnecessary complexity. NetworkManager (NM) create
 ``network-scripts`` files.
 
-:copyright: Copyright (c) 2018 RadiaSoft LLC.  All Rights Reserved.
+:copyright: Copyright (c) 2018-2022 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
-from rsconf import component
 from pykern import pkcollections
-from pykern.pkdebug import pkdp
-from pykern import pkio
 from pykern import pkcompat
+from pykern import pkio
+from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdp
+import rsconf
 import copy
 import ipaddress
 import socket
@@ -24,7 +23,7 @@ _RESOLV_CONF = pkio.py_path("/etc/resolv.conf")
 _IPTABLES = pkio.py_path("/etc/sysconfig/iptables")
 
 
-class T(component.T):
+class T(rsconf.component.T):
     def add_public_tcp_ports(self, ports):
         self._add_ports("public_tcp_ports", ports)
 
@@ -43,7 +42,6 @@ class T(component.T):
         self.j2_ctx = self.hdb.j2_ctx_copy()
         jc = self.j2_ctx
         z = jc.network
-        self._check_restricted_ports(z)
         z.trusted_nets = tuple(sorted(z.trusted.keys()))
         z.pksetdefault(
             blocked_ips=[],
@@ -52,6 +50,7 @@ class T(component.T):
             public_ssh_ports=[],
             public_tcp_ports=[],
             public_udp_ports=[],
+            restricted_public_tcp_ports=PKDict,
             trusted_tcp_ports=[],
         )
         self.__trusted_nets = self._nets(jc, z.trusted)
@@ -101,6 +100,7 @@ class T(component.T):
         jc = self.j2_ctx
         jc = self.j2_ctx
         z = jc.network
+        self._restricted_public_tcp_ports(z)
         if not "_devs" in z:
             # no devices, no network config
             self.append_root_bash(": nothing to do")
@@ -142,28 +142,32 @@ class T(component.T):
     def _add_ports(self, which, ports):
         assert len(ports[0]) > 2, "invalid ports: {}".format(ports)
         z = self.j2_ctx.network
-        check = (
+        c = (
             ("trusted_tcp_ports", "public_tcp_ports")
             if "tcp" in which
             else ("public_udp_ports",)
         )
         for p in ports:
-            for w in check:
+            for w in c:
                 assert not p in z[w], "port {} already in {}".format(p, w)
             z[which].append(p)
 
-    def _check_restricted_ports(self, z):
-        if "restrict_ports" not in z:
+    def _restricted_public_tcp_ports(self, z):
+        if not z.restricted_public_tcp_ports:
             return
         assert (
-            "443" not in z.restrict_ports
-        ), f"use https instead of 443 in restrict_ports={z.restrict_ports}"
-        assert (
-            "http" not in z.restrict_ports and "80" not in z.restrict_ports
-        ), f"only define https not http or 80 in restrict_ports={z.restrict_ports}"
-        if "https" not in z.restrict_ports:
-            return
-        z.restrict_ports["http"] = z.restrict_ports.https
+            z.iptables_enable
+        ), f"iptables must be configured for restricted_public_tcp_ports={z.restricted_public_tcp_ports}"
+        r = PKDict()
+        for k in sorted(z.restricted_public_tcp_ports.keys()):
+            assert (
+                k in z.public_tcp_ports
+            ), f"restricted_public_tcp_ports={k} must be in public_tcp_ports"
+            z.public_tcp_ports.remove(k)
+            r[k] = sorted(
+                str(self._net_or_ip(v)) for v in z.restricted_public_tcp_ports[k]
+            )
+        self.restricted_public_tcp_ports = r
 
     def _defroute(self, routes):
         defroute = None
@@ -216,9 +220,7 @@ class T(component.T):
         nets = pkcollections.Dict()
         for n, v in spec.items():
             v = copy.deepcopy(v)
-            # Avoid this error:
-            # Did you pass in a bytes (str in Python 2) instead of a unicode object?
-            n = ipaddress.ip_network(pkcompat.locale_str(n))
+            n = ipaddress.ip_network(n)
             v.name = n
             v.ip = str(n.network_address)
             v.netmask = str(n.netmask)
@@ -229,9 +231,9 @@ class T(component.T):
             )
             v.pksetdefault(is_private=lambda: not v.is_global and n.is_private)
             if v.gateway:
-                assert ipaddress.ip_network(
-                    pkcompat.locale_str(v.gateway + "/32")
-                ).subnet_of(n), "{}: gateway is not subnet of {}".format(v.gateway, n)
+                assert ipaddress.ip_network(v.gateway + "/32",).subnet_of(
+                    n
+                ), "{}: gateway is not subnet of {}".format(v.gateway, n)
             if "nameservers" in v:
                 v.nameservers = sorted([ipaddress.ip_address(x) for x in v.nameservers])
             nets[n] = v
@@ -239,7 +241,7 @@ class T(component.T):
 
     # TODO(robnagler) sanity check nets don't overlap?
     def _net_check(self, ip):
-        nip = ipaddress.ip_network(pkcompat.locale_str(ip + "/32"))
+        nip = ipaddress.ip_network(ip + "/32")
         # TODO(robnagler) untrusted networks are supernets of potentially trusted_nets
         # the only reason to add them is to find them for devices
         for nets in self.__untrusted_nets, self.__trusted_nets:
@@ -247,3 +249,6 @@ class T(component.T):
                 if nip.subnet_of(n):
                     return nets[n]
         raise AssertionError("{}: ip not found in un/trusted_networks".format(nip))
+
+    def _net_or_ip(self, val):
+        return ipaddress.ip_network(val) if "/" in val else ipaddress.ip_address(val)

--- a/rsconf/package_data/network/iptables.jinja
+++ b/rsconf/package_data/network/iptables.jinja
@@ -22,6 +22,10 @@
  #
  # robnagler: I figure it easier to stick with state.
  #}
+{% for p, n in network.get("restrict_ports", {}).items() %}
+    -A INPUT -i {{ network.inet_dev.name }} -p tcp -m state --state NEW -m tcp -s {{ n | join(',') }} --dport {{ p }} -j ACCEPT
+    -A INPUT -i {{ network.inet_dev.name }} -p tcp -m state --state NEW -m tcp --dport {{ p }} -j DROP
+{% endfor %}
 {% for d in network.private_devs %}
     -A INPUT -i {{ d }} -j ACCEPT
 {% endfor %}

--- a/rsconf/package_data/network/iptables.jinja
+++ b/rsconf/package_data/network/iptables.jinja
@@ -1,3 +1,8 @@
+{# iptables is a program run very every packet so put the rules for
+ # the earliest success first and the rules that give the latest failure
+ # last. This way an attacker does comsume more cpu, but that is more rare than
+ # making sure ESTABLISHED connections are recognized first.
+ #}
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]

--- a/rsconf/package_data/network/iptables.jinja
+++ b/rsconf/package_data/network/iptables.jinja
@@ -19,16 +19,11 @@
  # discussions, titled: state match is obsolete 1.4.17, which pretty much
  # says that state is just an alias to conntrack so it doesn't really
  # matter which you use, in both circumstances you're using conntrack.
- #
- # robnagler: I figure it easier to stick with state.
  #}
-{% for p, n in network.get("restrict_ports", {}).items() %}
-    -A INPUT -i {{ network.inet_dev.name }} -p tcp -m state --state NEW -m tcp -s {{ n | join(',') }} --dport {{ p }} -j ACCEPT
-    -A INPUT -i {{ network.inet_dev.name }} -p tcp -m state --state NEW -m tcp --dport {{ p }} -j DROP
-{% endfor %}
 {% for d in network.private_devs %}
     -A INPUT -i {{ d }} -j ACCEPT
 {% endfor %}
+-A INPUT -i {{ network.inet_dev.name }} -m state --state RELATED,ESTABLISHED -j ACCEPT
 {% if network.public_tcp_ports %}
     -A INPUT -i {{ network.inet_dev.name }} -p tcp -m state --state NEW -m tcp --match multiport --dports {{ network.public_tcp_ports | join(',') }} -j ACCEPT
 {% endif %}
@@ -40,7 +35,11 @@
 {% if network.public_udp_ports %}
     -A INPUT -i {{ network.inet_dev.name }} -p udp --match multiport --dports {{ network.public_udp_ports | join (',') }} -j ACCEPT
 {% endif %}
--A INPUT -i {{ network.inet_dev.name }} -m state --state RELATED,ESTABLISHED -j ACCEPT
+{% for p in network.restricted_public_tcp_ports %}
+    {% for n in network.restricted_public_tcp_ports[p] %}
+        -A INPUT -i {{ network.inet_dev.name }} -s {{ n }} -p tcp -m state --state NEW -m tcp --dport {{ p }}  -j ACCEPT
+    {% endfor %}
+{% endfor %}
 -A INPUT -i {{ network.inet_dev.name }} -m state --state INVALID -j REJECT --reject-with icmp-port-unreachable
 -A INPUT -i {{ network.inet_dev.name }} -p tcp -m tcp --tcp-flags SYN,RST,ACK ACK -m state --state NEW -j REJECT --reject-with tcp-reset
 -A INPUT -i {{ network.inet_dev.name }} -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m state --state NEW -j REJECT --reject-with icmp-port-unreachable

--- a/tests/pkcli/build_data/1-fconf.in/db/000.yml
+++ b/tests/pkcli/build_data/1-fconf.in/db/000.yml
@@ -458,8 +458,8 @@ host:
       jupyterhub_proxy:
         listen_any: True
       network:
-        restrict_ports:
-          https: [ 192.168.1.1/24, 127.0.0.1 ]
+        restricted_public_tcp_ports:
+          https: [ 192.168.1.0/24, 127.0.0.1 ]
         public_ssh_ports: [ 5555, 6666 ]
         public_tcp_ports: [ 9999 ]
         devices:

--- a/tests/pkcli/build_data/1-fconf.in/db/000.yml
+++ b/tests/pkcli/build_data/1-fconf.in/db/000.yml
@@ -458,6 +458,8 @@ host:
       jupyterhub_proxy:
         listen_any: True
       network:
+        restrict_ports:
+          https: [ 192.168.1.1/24, 127.0.0.1 ]
         public_ssh_ports: [ 5555, 6666 ]
         public_tcp_ports: [ 9999 ]
         devices:

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/etc/sysconfig/iptables
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/etc/sysconfig/iptables
@@ -6,6 +6,10 @@
     -A INPUT -s 99.99.99.0/24 -j DROP
 -A INPUT -p icmp --icmp-type timestamp-request -j DROP
 -A INPUT -p icmp -j ACCEPT
+    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp -s 192.168.1.1/24,127.0.0.1 --dport https -j ACCEPT
+    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --dport https -j DROP
+    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp -s 192.168.1.1/24,127.0.0.1 --dport http -j ACCEPT
+    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --dport http -j DROP
     -A INPUT -i lo -j ACCEPT
     -A INPUT -i em1 -j ACCEPT
     -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --match multiport --dports 3100,3101,9999,http,https,pop3s,smtp,submission -j ACCEPT

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/etc/sysconfig/iptables
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/etc/sysconfig/iptables
@@ -6,14 +6,12 @@
     -A INPUT -s 99.99.99.0/24 -j DROP
 -A INPUT -p icmp --icmp-type timestamp-request -j DROP
 -A INPUT -p icmp -j ACCEPT
-    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp -s 192.168.1.1/24,127.0.0.1 --dport https -j ACCEPT
-    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --dport https -j DROP
-    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp -s 192.168.1.1/24,127.0.0.1 --dport http -j ACCEPT
-    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --dport http -j DROP
     -A INPUT -i lo -j ACCEPT
     -A INPUT -i em1 -j ACCEPT
-    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --match multiport --dports 3100,3101,9999,http,https,pop3s,smtp,submission -j ACCEPT
 -A INPUT -i em2 -m state --state RELATED,ESTABLISHED -j ACCEPT
+    -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --match multiport --dports 3100,3101,9999,http,pop3s,smtp,submission -j ACCEPT
+        -A INPUT -i em2 -s 192.168.1.0/24 -p tcp -m state --state NEW -m tcp --dport https  -j ACCEPT
+        -A INPUT -i em2 -s 127.0.0.1 -p tcp -m state --state NEW -m tcp --dport https  -j ACCEPT
 -A INPUT -i em2 -m state --state INVALID -j REJECT --reject-with icmp-port-unreachable
 -A INPUT -i em2 -p tcp -m tcp --tcp-flags SYN,RST,ACK ACK -m state --state NEW -j REJECT --reject-with tcp-reset
 -A INPUT -i em2 -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m state --state NEW -j REJECT --reject-with icmp-port-unreachable

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/network.sh
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/network.sh
@@ -6,7 +6,7 @@ rsconf_install_access '444' 'root' 'root'
 rsconf_install_file '/etc/resolv.conf' 'c333a7a816c03062d4e61effd6d2a8ce'
 rsconf_install_file '/etc/sysconfig/network-scripts/ifcfg-em1' 'e225a3f7b4b071e5c204b1182c17ab94'
 rsconf_install_file '/etc/sysconfig/network-scripts/ifcfg-em2' '4f8c01335a3bf1a8a89ba5d09fdf28df'
-rsconf_install_file '/etc/sysconfig/iptables' 'e6a7ca3e9d9189c42a9bbb729f2a122f'
+rsconf_install_file '/etc/sysconfig/iptables' '172b0e72159bef4fa3146ffc9a8c7a16'
 network_main
 }
 #!/bin/bash

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/network.sh
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/network.sh
@@ -6,7 +6,7 @@ rsconf_install_access '444' 'root' 'root'
 rsconf_install_file '/etc/resolv.conf' 'c333a7a816c03062d4e61effd6d2a8ce'
 rsconf_install_file '/etc/sysconfig/network-scripts/ifcfg-em1' 'e225a3f7b4b071e5c204b1182c17ab94'
 rsconf_install_file '/etc/sysconfig/network-scripts/ifcfg-em2' '4f8c01335a3bf1a8a89ba5d09fdf28df'
-rsconf_install_file '/etc/sysconfig/iptables' '172b0e72159bef4fa3146ffc9a8c7a16'
+rsconf_install_file '/etc/sysconfig/iptables' '0097f7e4e29b45b9e3aa8d3950318f58'
 network_main
 }
 #!/bin/bash


### PR DESCRIPTION
You can define
```
network:
  restrict_ports:
    https: [ 192.168.1.1/24 ]
```

That will restrict traffic on https port to traffic from only 192.168.1.1/24.

http will be added for you.