### PR TITLE
Fix #259 atomic writes & not recursively rsync

### DIFF
--- a/rsconf/package_data/bkp/secondary.sh.jinja
+++ b/rsconf/package_data/bkp/secondary.sh.jinja
@@ -22,17 +22,17 @@ secondary_err() {
 }
 
 secondary_file_sys() {
-    local file=$1
-    local x=( $(df "$file" | tail -1) )
+    declare file=$1
+    declare x=( $(df "$file" | tail -1) )
     echo "${x[0]}"
 }
 
 secondary_main() {
     umask 077
-    local snap=$secondary_mirror_d/secondary_snap
-    local dst_d snap_d base_d copy_txz
-    local -i retries
-    local is_restart=
+    declare snap=$secondary_mirror_d/secondary_snap
+    declare dst_d snap_d base_d copy_txz copy_tmp
+    declare -i retries
+    declare is_restart=
     if [[ -e $snap/RESTART ]]; then
         is_restart=1
         rm "$snap"/RESTART
@@ -53,10 +53,17 @@ secondary_main() {
         snap_d=$snap/$base_d
         copy_d=$secondary_copy_d/$base_d
         copy_txz=$copy_d/0.txz
-        if [[ $base_d =~ srv/github_bkp/db/.+$ ]]; then
-            # github_bkp is already compressed so just
+        copy_tmp=$copy_txz.tmp
+        if [[ $base_d =~ srv/github_bkp/db/(.+)$ ]]; then
+            if [[ ${BASH_REMATCH[1]} =~ / ]]; then
+                # the rsync does all the work for sub directories.
+                # Paren (github_bkp/db) falls through below as an empty directory
+                continue
+            fi
+            # github_bkp is already compressed so just copy
             secondary_msg "Simple copy: $base_d"
-            cp -a "$snap_d" "$copy_d"
+            # handles restarts properly
+            rsync -a "$snap_d" "$copy_d"
             continue
         fi
         mkdir -p "$copy_d"
@@ -66,6 +73,7 @@ secondary_main() {
         fi
         if [[ $is_restart && -s $copy_txz ]]; then
             # Reusing $copy_txz if it is non-zero size
+            rm -f "$copy_tmp"
             continue
         fi
         i=3
@@ -81,9 +89,11 @@ secondary_main() {
                 find . -maxdepth 1 ! -type d -print0 \
                     | grep --text --null --null-data -v --perl-regexp '\\' \
                     | tar --create --null --files-from=- --file=-
-            ) | pxz -T8 -9 > "$copy_txz"; then
+            ) | pxz -T8 -9 > "$copy_tmp"; then
+                mv "$copy_tmp" "$copy_txz"
                 break
             fi
+            rm -f "$copy_tmp"
             i+=-1
             if (( i < 0 )); then
                 secondary_msg "FAILED COPY $copy_d, continuing"

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/bkp.sh
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/bkp.sh
@@ -2,7 +2,7 @@
 bkp_rsconf_component() {
 rsconf_service_prepare 'bkp.timer' '/etc/systemd/system/bkp.service' '/etc/systemd/system/bkp.timer' '/srv/bkp'
 rsconf_install_access '500' 'root' 'root'
-rsconf_install_file '/srv/bkp/secondary' 'b378d96f4acf76465a22b7f1719645bc'
+rsconf_install_file '/srv/bkp/secondary' 'c18b548ce38fe67c256d8437889662a4'
 rsconf_install_file '/srv/bkp/secondary_setup' '84b40460f8374ccbde4c353cc301f5fc'
 rsconf_install_access '700' 'root' 'root'
 rsconf_install_directory '/srv/bkp'

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/srv/bkp/secondary
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/srv/bkp/secondary
@@ -22,17 +22,17 @@ secondary_err() {
 }
 
 secondary_file_sys() {
-    local file=$1
-    local x=( $(df "$file" | tail -1) )
+    declare file=$1
+    declare x=( $(df "$file" | tail -1) )
     echo "${x[0]}"
 }
 
 secondary_main() {
     umask 077
-    local snap=$secondary_mirror_d/secondary_snap
-    local dst_d snap_d base_d copy_txz
-    local -i retries
-    local is_restart=
+    declare snap=$secondary_mirror_d/secondary_snap
+    declare dst_d snap_d base_d copy_txz copy_tmp
+    declare -i retries
+    declare is_restart=
     if [[ -e $snap/RESTART ]]; then
         is_restart=1
         rm "$snap"/RESTART
@@ -53,10 +53,17 @@ secondary_main() {
         snap_d=$snap/$base_d
         copy_d=$secondary_copy_d/$base_d
         copy_txz=$copy_d/0.txz
-        if [[ $base_d =~ srv/github_bkp/db/.+$ ]]; then
-            # github_bkp is already compressed so just
+        copy_tmp=$copy_txz.tmp
+        if [[ $base_d =~ srv/github_bkp/db/(.+)$ ]]; then
+            if [[ ${BASH_REMATCH[1]} =~ / ]]; then
+                # the rsync does all the work for sub directories.
+                # Paren (github_bkp/db) falls through below as an empty directory
+                continue
+            fi
+            # github_bkp is already compressed so just copy
             secondary_msg "Simple copy: $base_d"
-            cp -a "$snap_d" "$copy_d"
+            # handles restarts properly
+            rsync -a "$snap_d" "$copy_d"
             continue
         fi
         mkdir -p "$copy_d"
@@ -66,6 +73,7 @@ secondary_main() {
         fi
         if [[ $is_restart && -s $copy_txz ]]; then
             # Reusing $copy_txz if it is non-zero size
+            rm -f "$copy_tmp"
             continue
         fi
         i=3
@@ -81,9 +89,11 @@ secondary_main() {
                 find . -maxdepth 1 ! -type d -print0 \
                     | grep --text --null --null-data -v --perl-regexp '\\' \
                     | tar --create --null --files-from=- --file=-
-            ) | pxz -T8 -9 > "$copy_txz"; then
+            ) | pxz -T8 -9 > "$copy_tmp"; then
+                mv "$copy_tmp" "$copy_txz"
                 break
             fi
+            rm -f "$copy_tmp"
             i+=-1
             if (( i < 0 )); then
                 secondary_msg "FAILED COPY $copy_d, continuing"

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/bkp.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/bkp.sh
@@ -2,7 +2,7 @@
 bkp_rsconf_component() {
 rsconf_service_prepare 'bkp.timer' '/etc/systemd/system/bkp.service' '/etc/systemd/system/bkp.timer' '/srv/bkp'
 rsconf_install_access '500' 'root' 'root'
-rsconf_install_file '/srv/bkp/secondary' 'b378d96f4acf76465a22b7f1719645bc'
+rsconf_install_file '/srv/bkp/secondary' 'c18b548ce38fe67c256d8437889662a4'
 rsconf_install_file '/srv/bkp/secondary_setup' '84b40460f8374ccbde4c353cc301f5fc'
 rsconf_install_access '700' 'root' 'root'
 rsconf_install_directory '/srv/bkp'

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/srv/bkp/secondary
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/srv/bkp/secondary
@@ -22,17 +22,17 @@ secondary_err() {
 }
 
 secondary_file_sys() {
-    local file=$1
-    local x=( $(df "$file" | tail -1) )
+    declare file=$1
+    declare x=( $(df "$file" | tail -1) )
     echo "${x[0]}"
 }
 
 secondary_main() {
     umask 077
-    local snap=$secondary_mirror_d/secondary_snap
-    local dst_d snap_d base_d copy_txz
-    local -i retries
-    local is_restart=
+    declare snap=$secondary_mirror_d/secondary_snap
+    declare dst_d snap_d base_d copy_txz copy_tmp
+    declare -i retries
+    declare is_restart=
     if [[ -e $snap/RESTART ]]; then
         is_restart=1
         rm "$snap"/RESTART
@@ -53,10 +53,17 @@ secondary_main() {
         snap_d=$snap/$base_d
         copy_d=$secondary_copy_d/$base_d
         copy_txz=$copy_d/0.txz
-        if [[ $base_d =~ srv/github_bkp/db/.+$ ]]; then
-            # github_bkp is already compressed so just
+        copy_tmp=$copy_txz.tmp
+        if [[ $base_d =~ srv/github_bkp/db/(.+)$ ]]; then
+            if [[ ${BASH_REMATCH[1]} =~ / ]]; then
+                # the rsync does all the work for sub directories.
+                # Paren (github_bkp/db) falls through below as an empty directory
+                continue
+            fi
+            # github_bkp is already compressed so just copy
             secondary_msg "Simple copy: $base_d"
-            cp -a "$snap_d" "$copy_d"
+            # handles restarts properly
+            rsync -a "$snap_d" "$copy_d"
             continue
         fi
         mkdir -p "$copy_d"
@@ -66,6 +73,7 @@ secondary_main() {
         fi
         if [[ $is_restart && -s $copy_txz ]]; then
             # Reusing $copy_txz if it is non-zero size
+            rm -f "$copy_tmp"
             continue
         fi
         i=3
@@ -81,9 +89,11 @@ secondary_main() {
                 find . -maxdepth 1 ! -type d -print0 \
                     | grep --text --null --null-data -v --perl-regexp '\\' \
                     | tar --create --null --files-from=- --file=-
-            ) | pxz -T8 -9 > "$copy_txz"; then
+            ) | pxz -T8 -9 > "$copy_tmp"; then
+                mv "$copy_tmp" "$copy_txz"
                 break
             fi
+            rm -f "$copy_tmp"
             i+=-1
             if (( i < 0 )); then
                 secondary_msg "FAILED COPY $copy_d, continuing"


### PR DESCRIPTION
- cp was being called recursively, when it was being passed `-a`  which was already recursive. Change to rsync (better for restarts) and don't recurse tree calling rsync.
- write a tmp and then move if `tar|pxz` works
- change local to declare
