### PR TITLE
Fix #261 added --hard-links and copy github_bkp/db at once

### DIFF
--- a/rsconf/package_data/bkp/secondary.sh.jinja
+++ b/rsconf/package_data/bkp/secondary.sh.jinja
@@ -54,16 +54,15 @@ secondary_main() {
         copy_d=$secondary_copy_d/$base_d
         copy_txz=$copy_d/0.txz
         copy_tmp=$copy_txz.tmp
-        if [[ $base_d =~ srv/github_bkp/db/(.+)$ ]]; then
-            if [[ ${BASH_REMATCH[1]} =~ / ]]; then
-                # the rsync does all the work for sub directories.
-                # Paren (github_bkp/db) falls through below as an empty directory
-                continue
-            fi
+        if [[ $base_d =~ srv/github_bkp/db/ ]]; then
+            # the rsync (below) does all the work for sub directories
+            continue
+        elif [[ $base_d =~ srv/github_bkp/db$ ]]; then
             # github_bkp is already compressed so just copy
+            # must be at this level to copy hard-links
             secondary_msg "Simple copy: $base_d"
             # handles restarts properly
-            rsync -a "$snap_d" "$copy_d"
+            rsync -a --hard-links --sparse "$snap_d" "$(dirname "$copy_d")"
             continue
         fi
         mkdir -p "$copy_d"

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/bkp.sh
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/bkp.sh
@@ -2,7 +2,7 @@
 bkp_rsconf_component() {
 rsconf_service_prepare 'bkp.timer' '/etc/systemd/system/bkp.service' '/etc/systemd/system/bkp.timer' '/srv/bkp'
 rsconf_install_access '500' 'root' 'root'
-rsconf_install_file '/srv/bkp/secondary' 'c18b548ce38fe67c256d8437889662a4'
+rsconf_install_file '/srv/bkp/secondary' 'f91c10fc0fdfe67360067343a2577c1b'
 rsconf_install_file '/srv/bkp/secondary_setup' '84b40460f8374ccbde4c353cc301f5fc'
 rsconf_install_access '700' 'root' 'root'
 rsconf_install_directory '/srv/bkp'

--- a/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/srv/bkp/secondary
+++ b/tests/pkcli/build_data/1-fconf.out/srv/host/v9.radia.run/srv/bkp/secondary
@@ -54,16 +54,15 @@ secondary_main() {
         copy_d=$secondary_copy_d/$base_d
         copy_txz=$copy_d/0.txz
         copy_tmp=$copy_txz.tmp
-        if [[ $base_d =~ srv/github_bkp/db/(.+)$ ]]; then
-            if [[ ${BASH_REMATCH[1]} =~ / ]]; then
-                # the rsync does all the work for sub directories.
-                # Paren (github_bkp/db) falls through below as an empty directory
-                continue
-            fi
+        if [[ $base_d =~ srv/github_bkp/db/ ]]; then
+            # the rsync (below) does all the work for sub directories
+            continue
+        elif [[ $base_d =~ srv/github_bkp/db$ ]]; then
             # github_bkp is already compressed so just copy
+            # must be at this level to copy hard-links
             secondary_msg "Simple copy: $base_d"
             # handles restarts properly
-            rsync -a "$snap_d" "$copy_d"
+            rsync -a --hard-links --sparse "$snap_d" "$(dirname "$copy_d")"
             continue
         fi
         mkdir -p "$copy_d"

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/bkp.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/bkp.sh
@@ -2,7 +2,7 @@
 bkp_rsconf_component() {
 rsconf_service_prepare 'bkp.timer' '/etc/systemd/system/bkp.service' '/etc/systemd/system/bkp.timer' '/srv/bkp'
 rsconf_install_access '500' 'root' 'root'
-rsconf_install_file '/srv/bkp/secondary' 'c18b548ce38fe67c256d8437889662a4'
+rsconf_install_file '/srv/bkp/secondary' 'f91c10fc0fdfe67360067343a2577c1b'
 rsconf_install_file '/srv/bkp/secondary_setup' '84b40460f8374ccbde4c353cc301f5fc'
 rsconf_install_access '700' 'root' 'root'
 rsconf_install_directory '/srv/bkp'

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/srv/bkp/secondary
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/srv/bkp/secondary
@@ -54,16 +54,15 @@ secondary_main() {
         copy_d=$secondary_copy_d/$base_d
         copy_txz=$copy_d/0.txz
         copy_tmp=$copy_txz.tmp
-        if [[ $base_d =~ srv/github_bkp/db/(.+)$ ]]; then
-            if [[ ${BASH_REMATCH[1]} =~ / ]]; then
-                # the rsync does all the work for sub directories.
-                # Paren (github_bkp/db) falls through below as an empty directory
-                continue
-            fi
+        if [[ $base_d =~ srv/github_bkp/db/ ]]; then
+            # the rsync (below) does all the work for sub directories
+            continue
+        elif [[ $base_d =~ srv/github_bkp/db$ ]]; then
             # github_bkp is already compressed so just copy
+            # must be at this level to copy hard-links
             secondary_msg "Simple copy: $base_d"
             # handles restarts properly
-            rsync -a "$snap_d" "$copy_d"
+            rsync -a --hard-links --sparse "$snap_d" "$(dirname "$copy_d")"
             continue
         fi
         mkdir -p "$copy_d"


### PR DESCRIPTION
The previous pattern was duplicate copying, too. This one copies at the top level so that all the date directories get hard-linked and skips the rest.