### PR TITLE
Fix #333 PCI compliance requires server software version be omitted

### DIFF
--- a/rsconf/package_data/nginx/global.conf.jinja
+++ b/rsconf/package_data/nginx/global.conf.jinja
@@ -54,6 +54,7 @@ http {
         ;
     {# https://t37.net/nginx-optimization-understanding-sendfile-tcp_nodelay-and-tcp_nopush.html #}
     sendfile on;
+    server_tokens off;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;

--- a/tests/pkcli/build_data/1.out/srv/host/v3.radia.run/etc/nginx/nginx.conf
+++ b/tests/pkcli/build_data/1.out/srv/host/v3.radia.run/etc/nginx/nginx.conf
@@ -43,6 +43,7 @@ http {
         text/xml
         ;
     sendfile on;
+    server_tokens off;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;

--- a/tests/pkcli/build_data/1.out/srv/host/v3.radia.run/nginx.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v3.radia.run/nginx.sh
@@ -6,7 +6,7 @@ rsconf_service_prepare 'nginx' '/etc/systemd/system/nginx.service' '/etc/systemd
 rsconf_install_access '400' 'root' 'root'
 rsconf_install_file '/etc/nginx/conf.d/v3.radia.run.key' 'b98bb61f3b76969ee1a259d5a1afd5f1'
 rsconf_install_file '/etc/nginx/conf.d/v3.radia.run.crt' '71151618f3ca16bad2d73ef5a6683c1c'
-rsconf_install_file '/etc/nginx/nginx.conf' '4d818eb80f882af9ebc7aa39be02bde7'
+rsconf_install_file '/etc/nginx/nginx.conf' '84b02225b46b3fbc4b82d9f9c45cb3eb'
 rsconf_install_access '755' 'root' 'root'
 rsconf_install_directory '/srv/www'
 rsconf_service_restart_at_end 'nginx'

--- a/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/etc/nginx/nginx.conf
+++ b/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/etc/nginx/nginx.conf
@@ -43,6 +43,7 @@ http {
         text/xml
         ;
     sendfile on;
+    server_tokens off;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;

--- a/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/nginx.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/nginx.sh
@@ -8,7 +8,7 @@ rsconf_install_file '/etc/nginx/conf.d/www.redirect3.v4.radia.run.key' '41358777
 rsconf_install_file '/etc/nginx/conf.d/www.redirect3.v4.radia.run.crt' 'bc90227f5d1ee11128b7b29283f789fd'
 rsconf_service_prepare 'nginx' '/etc/systemd/system/nginx.service' '/etc/systemd/system/nginx.service.d' '/etc/nginx'
 rsconf_install_access '400' 'root' 'root'
-rsconf_install_file '/etc/nginx/nginx.conf' 'c84280939faeb6cad55ebefc68feeebe'
+rsconf_install_file '/etc/nginx/nginx.conf' '7009fb4c4f580b07a51dc768740c222c'
 rsconf_install_access '755' 'root' 'root'
 rsconf_install_directory '/srv/www'
 rsconf_service_restart_at_end 'nginx'

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/etc/nginx/nginx.conf
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/etc/nginx/nginx.conf
@@ -43,6 +43,7 @@ http {
         text/xml
         ;
     sendfile on;
+    server_tokens off;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/nginx.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/nginx.sh
@@ -6,7 +6,7 @@ rsconf_service_prepare 'nginx' '/etc/systemd/system/nginx.service' '/etc/systemd
 rsconf_install_access '400' 'root' 'root'
 rsconf_install_file '/etc/nginx/conf.d/v9.radia.run.key' 'fe22a3a98b83d3cd8d48eb5ccda07d60'
 rsconf_install_file '/etc/nginx/conf.d/v9.radia.run.crt' 'a6d3bba40727a12f03b1f44727bb98be'
-rsconf_install_file '/etc/nginx/nginx.conf' '35b94f63edf20da8e8b94f8502ed0e0e'
+rsconf_install_file '/etc/nginx/nginx.conf' '25a5bf409a10dd0f2e2c4e950be9a2f9'
 rsconf_install_access '755' 'root' 'root'
 rsconf_install_directory '/srv/www'
 rsconf_service_restart_at_end 'nginx'


### PR DESCRIPTION
Verified locally that the nginx version is ommitted from the `Server` header with this change.