### PR TITLE
Fix #428 add script.timers

### DIFF
--- a/rsconf/component/__init__.py
+++ b/rsconf/component/__init__.py
@@ -202,7 +202,23 @@ class T(PKDict):
         )
         return r
 
-    def install_resource(self, name, j2_ctx, host_path=None):
+    def install_resource(self, name, j2_ctx=None, host_path=None):
+        """Resource file `name` will be copied to guest path
+
+        If `host_path` is not supplied, `name` will be used as
+        `host_path`, and `name` will be modified to be ``module_name/name.basename``.
+
+        Args:
+            name (object): str path or py.path to install
+            j2_ctx (PKDict): jinja context to use [self.j2_ctx]
+            host_path (py.path): where on host to install the file
+
+        Returns:
+            py.path: `host_path`
+
+        """
+        if j2_ctx is None:
+            j2_ctx = self.j2_ctx
         if not host_path:
             host_path = name
             if host_path.ext == ".sh":

--- a/rsconf/component/script.py
+++ b/rsconf/component/script.py
@@ -1,17 +1,49 @@
 # -*- coding: utf-8 -*-
-"""run arbitrary scripts with dependencies
+"""run arbitrary scripts and timers
 
 :copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from pykern.pkdebug import pkdp
+from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdp, pkdlog
 from rsconf import component
 
 
 class T(component.T):
     def internal_build_compile(self):
-        _, z = self.j2_ctx_init()
+        from rsconf import systemd
+
+        jc, z = self.j2_ctx_init()
         self.buildt.require_component(*(z.get("require_components", ["base_users"])))
+        jc.pksetdefault(timers=PKDict)
+        for k, v in z.timers.items():
+            v._run_d = systemd.unit_run_d(jc, k)
+            v._run_f = v._run_d.join("run")
+            v.pksetdefault(run_u=jc.rsconf_db.root_u)
+            for x in "on_calendar", "bash_script":
+                if x not in v:
+                    raise AssertionError(f"missing param={x} in script.timers.{k}")
 
     def internal_build_write(self):
-        self.append_root_bash(self.j2_ctx.script.bash)
+        from rsconf import systemd
+
+        jc = self.j2_ctx
+        z = jc[self.name]
+        if s := (z.get("rsconf_bash") or z.get("bash")):
+            if z.get("bash"):
+                pkdlog("script.bash is deprecated use script.rsconf_bash")
+            self.append_root_bash(s)
+        for k in sorted(z.timers.keys()):
+            v = z.timers[k]
+            z.curr_timer = v
+            systemd.timer_prepare(
+                self,
+                jc,
+                # TODO(robnagler) time zone
+                on_calendar=v.on_calendar,
+                service_name=k,
+                timer_exec=v._run_f,
+            )
+            self.install_access(mode="500", owner=v.run_u)
+            self.install_resource("script/timer.sh", host_path=v._run_f)
+            systemd.timer_enable(self, run_u=v.run_u)

--- a/rsconf/package_data/dev/db/000.yml.jinja
+++ b/rsconf/package_data/dev/db/000.yml.jinja
@@ -435,6 +435,8 @@ host:
               - 1
               - 2
               - 3
+      github_bkp:
+        org: radiasoft
       jupyterhub:
         jupyter_docker_image: radiasoft/custom-jupyter:latest
         jupyter_docker_image_is_local: true

--- a/rsconf/package_data/rsconf/nginx.conf.jinja
+++ b/rsconf/package_data/rsconf/nginx.conf.jinja
@@ -10,6 +10,8 @@ server {
     root {{ nginx.default_root }};
     ssl_certificate {{ nginx.tls_crt }};
     ssl_certificate_key {{ nginx.tls_key }};
+    keepalive_timeout 0;
+
     location / {
         root {{ rsconf.srv_d }};
         try_files $uri $uri/index.sh $uri/index.html =404;

--- a/rsconf/package_data/script/timer.sh.jinja
+++ b/rsconf/package_data/script/timer.sh.jinja
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+{{ script.curr_timer.bash_script }}

--- a/rsconf/systemd.py
+++ b/rsconf/systemd.py
@@ -260,7 +260,9 @@ def install_unit_override(compt, j2_ctx):
     )
 
 
-def timer_enable(compt, j2_ctx, run_u=None):
+def timer_enable(compt, j2_ctx=None, run_u=None):
+    if j2_ctx is None:
+        j2_ctx = compt.j2_ctx
     z = j2_ctx.systemd
     z.run_u = run_u or j2_ctx.rsconf_db.run_u
     compt.install_access(mode="700", owner=z.run_u)

--- a/tests/pkcli/build_data/1.in/db/000.yml
+++ b/tests/pkcli/build_data/1.in/db/000.yml
@@ -359,8 +359,14 @@ host:
         #components: [ bkp, jupyterhub, jupyterhub_proxy ]
         components: [ postfix, nfs_server, sirepo, script ]
       script:
-        bash: |
+        rsconf_bash: |
           echo hello
+
+        timers:
+          every_five:
+            on_calendar: "*:0/5"
+            bash_script: |
+              echo five
 
       sirepo:
         auth:

--- a/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/script.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/script.sh
@@ -4,7 +4,7 @@ echo hello
 
 rsconf_service_prepare 'every_five.timer' '/etc/systemd/system/every_five.service' '/etc/systemd/system/every_five.timer' '/srv/every_five'
 rsconf_install_access '500' 'root' 'root'
-rsconf_install_file '/srv/every_five/run' '99fa414cbe03e1be17e1512c93caa413'
+rsconf_install_file '/srv/every_five/run' '15bb1f8cf012034cd494dd3e96d8bc76'
 rsconf_install_access '700' 'root' 'root'
 rsconf_install_directory '/srv/every_five'
 rsconf_install_access '500' 'root' 'root'

--- a/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/script.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v4.radia.run/script.sh
@@ -2,4 +2,14 @@
 script_rsconf_component() {
 echo hello
 
+rsconf_service_prepare 'every_five.timer' '/etc/systemd/system/every_five.service' '/etc/systemd/system/every_five.timer' '/srv/every_five'
+rsconf_install_access '500' 'root' 'root'
+rsconf_install_file '/srv/every_five/run' '99fa414cbe03e1be17e1512c93caa413'
+rsconf_install_access '700' 'root' 'root'
+rsconf_install_directory '/srv/every_five'
+rsconf_install_access '500' 'root' 'root'
+rsconf_install_file '/srv/every_five/start' '4ec245b018ccd9d3439958d81bf70acf'
+rsconf_install_access '444' 'root' 'root'
+rsconf_install_file '/etc/systemd/system/every_five.timer' 'd9cf11885ef351c6de1459426f91c654'
+rsconf_install_file '/etc/systemd/system/every_five.service' '8ba4919aed381df75e79c8780bb1acf6'
 }


### PR DESCRIPTION
- script.bash is deprecated in favor of script.rsconf_bash
- rsconf nginx config: turn off keepalive 
