### PR TITLE
Fix #440: various fixes for vm_devbox systemd

### DIFF
--- a/rsconf/component/vm_devbox.py
+++ b/rsconf/component/vm_devbox.py
@@ -41,8 +41,9 @@ class T(component.T):
         z.ssh_guest_host_key_f = "/etc/ssh/host_key"
         z.ssh_guest_identity_pub_f = "/etc/ssh/identity.pub"
         z.start_f = z.run_d.join("start")
+        z.stop_f = z.run_d.join("stop")
         z.vm_hostname = f"{self._user}.{jc[self.module_name].vm_parent_domain}"
-        systemd.unit_prepare(self, self.j2_ctx, watch_files=(z.start_f,))
+        systemd.unit_prepare(self, self.j2_ctx, watch_files=(z.start_f, z.stop_f))
         self._network(jc, z)
         self._ssh(jc, z)
 
@@ -56,6 +57,7 @@ class T(component.T):
         self.install_directory(z.run_d)
         self.install_access(mode="500", owner=z.run_u)
         self.install_resource("vm_devbox/start.sh", host_path=z.start_f)
+        self.install_resource("vm_devbox/start.sh", host_path=z.stop_f)
         self.install_access(mode="444", owner=jc.rsconf_db.root_u)
         self.install_resource(
             "vm_devbox/vm_devbox_unit_service", jc, jc.systemd.service_f

--- a/rsconf/package_data/vm_devbox/start.sh.jinja
+++ b/rsconf/package_data/vm_devbox/start.sh.jinja
@@ -27,6 +27,7 @@ _FORWARDED_PORT_FULL = (
         _FORWARDED_PORT_PREAMBLE
     )
 )
+r = False
 with open(_FILE) as f:
     c = f.read()
     if _FORWARDED_PORT_PREAMBLE not in c:
@@ -36,6 +37,7 @@ with open(_FILE) as f:
             c,
             flags=re.MULTILINE,
         )
+        r = True
     elif _FORWARDED_PORT_FULL not in c:
         c = re.sub(
             r"^\s*{}.*$".format(_FORWARDED_PORT_PREAMBLE),
@@ -43,8 +45,11 @@ with open(_FILE) as f:
             c,
             flags=re.MULTILINE,
         )
+        r = True
 with open(_FILE, 'w') as f:
     f.write(c)
+if r:
+    subprocess.check_call(('vagrant', 'reload'))
 EOF
 }
 

--- a/rsconf/package_data/vm_devbox/stop.sh.jinja
+++ b/rsconf/package_data/vm_devbox/stop.sh.jinja
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eou pipefail
+
+vm_devbox_main() {
+    cd {{ this.run_d }}
+    vagrant halt
+}
+
+vm_devbox_main

--- a/rsconf/package_data/vm_devbox/vm_devbox_unit_service.jinja
+++ b/rsconf/package_data/vm_devbox/vm_devbox_unit_service.jinja
@@ -4,11 +4,11 @@ Description={{ systemd.service_name }}
 [Service]
 Environment=TZ=:/etc/localtime
 ExecStart={{ this.start_f }}
-ExecStop=-vagrant halt
+ExecStop={{ this.stop_f }}
 Group={{ this.run_u }}
-PrivateTmp=true
 SyslogIdentifier={{ systemd.service_name }}
-Type=oneshot
+TimeoutStartSec=10min
+Type=forking
 User={{ this.run_u }}
 
 [Install]

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/srv/vm_devbox_user-1/start
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/srv/vm_devbox_user-1/start
@@ -27,6 +27,7 @@ _FORWARDED_PORT_FULL = (
         _FORWARDED_PORT_PREAMBLE
     )
 )
+r = False
 with open(_FILE) as f:
     c = f.read()
     if _FORWARDED_PORT_PREAMBLE not in c:
@@ -36,6 +37,7 @@ with open(_FILE) as f:
             c,
             flags=re.MULTILINE,
         )
+        r = True
     elif _FORWARDED_PORT_FULL not in c:
         c = re.sub(
             r"^\s*{}.*$".format(_FORWARDED_PORT_PREAMBLE),
@@ -43,8 +45,11 @@ with open(_FILE) as f:
             c,
             flags=re.MULTILINE,
         )
+        r = True
 with open(_FILE, 'w') as f:
     f.write(c)
+if r:
+    subprocess.check_call(('vagrant', 'reload'))
 EOF
 }
 

--- a/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/vm_devbox_user-1.sh
+++ b/tests/pkcli/build_data/1.out/srv/host/v9.radia.run/vm_devbox_user-1.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 vm_devbox_user-1_rsconf_component() {
-rsconf_service_prepare 'vm_devbox_user-1' '/etc/systemd/system/vm_devbox_user-1.service' '/etc/systemd/system/vm_devbox_user-1.service.d' '/srv/vm_devbox_user-1/start'
+rsconf_service_prepare 'vm_devbox_user-1' '/etc/systemd/system/vm_devbox_user-1.service' '/etc/systemd/system/vm_devbox_user-1.service.d' '/srv/vm_devbox_user-1/start' '/srv/vm_devbox_user-1/stop'
 rsconf_install_access '700' 'vagrant' 'vagrant'
 rsconf_install_directory '/srv/vm_devbox_user-1'
 rsconf_install_access '500' 'vagrant' 'vagrant'
-rsconf_install_file '/srv/vm_devbox_user-1/start' 'b7d61a2d0f37dc1abdf8a6a799ac25fb'
+rsconf_install_file '/srv/vm_devbox_user-1/start' '5dc3180f1dfd32e5d9d15e426928e94a'
+rsconf_install_file '/srv/vm_devbox_user-1/stop' '5dc3180f1dfd32e5d9d15e426928e94a'
 rsconf_install_access '444' 'root' 'root'
-rsconf_install_file '/etc/systemd/system/vm_devbox_user-1.service' '1bd0318206a0d747ce7ab0247d1d6b39'
+rsconf_install_file '/etc/systemd/system/vm_devbox_user-1.service' 'bcc048be3260244008a695125c53fc9f'
 }


### PR DESCRIPTION
- remove PrivateTmp this was causing many problems
- Type=forking the vm process forks and stays running after vagrant up exits
- vagrant reload after setting forwarded_port (need to reload for change to take)
- execStop needs to be an abspath and needs to be in /srv/vm_devbox_user. Just use a stop script and call it
- TimeoutStartSec=10min. With Type=forking the timeout is at play