### PR TITLE
Fix #448: switch to Type=oneshot

### DIFF
--- a/rsconf/package_data/vm_devbox/vm_devbox_unit_service.jinja
+++ b/rsconf/package_data/vm_devbox/vm_devbox_unit_service.jinja
@@ -6,9 +6,11 @@ Environment=TZ=:/etc/localtime
 ExecStart={{ this.start_f }}
 ExecStop={{ this.stop_f }}
 Group={{ this.run_u }}
+KillMode=none
+RemainAfterExit=yes
 SyslogIdentifier={{ systemd.service_name }}
 TimeoutStartSec={{ this.timeout_start_min }}min
-Type=forking
+Type=oneshot
 User={{ this.run_u }}
 
 [Install]


### PR DESCRIPTION
With Type=forking systemd tried to monitor the forked process. This allows it to know things like when the service dies. But, the way vagrant (and vbox underneath) daemonizes confuses systemd. So, if there are multiple vm's started that are managed by systemd all but the first start and then are immediately shutdown.

Type=oneshot makes it so systemd starts the process but then doesn't monitor it. RemainAfterExit=yes makes it so systemd assumes the service stays running. KillMode=none makes it so on systemctl stop systemd doesn't send a kill to all processes that were started when systemctl start was executed. On start of first vm on the machine VirtualBox starts a server daemon process which needs to not be killed.

These settings make it so systemd states will only change when a systemctl command is issued. This can lead to confusing behavior where a vm might stop outside of systemd's control (ex a manual vagrant halt) but systemd will still report the service as "active".