### PR TITLE
Fix #655 clear /dev/shm on each mpi host before running

### DIFF
--- a/rsconf/package_data/mpi_worker/rsmpi.sh.jinja
+++ b/rsconf/package_data/mpi_worker/rsmpi.sh.jinja
@@ -221,7 +221,7 @@ rsmpi_ping() {
             -o IdentityFile="$_rsmpi_conf_d/$h"/identity \
             -o StrictHostKeyChecking=no \
             -o UserKnownHostsFile=/dev/null \
-            "$h" hostname 2>/dev/null < /dev/null || true)
+            "$h" 'find /dev/shm -mindepth 1 -delete 2>/dev/null || true; hostname' 2>/dev/null < /dev/null || true)
         if [[ $x == $h ]]; then
             ok+=1
         else

--- a/tests/pkcli/build1_data/1.out/srv/host/v5.radia.run/mpi_worker.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v5.radia.run/mpi_worker.sh
@@ -16,7 +16,7 @@ rsconf_install_file '/srv/mpi_worker/user/vagrant/.rsmpi/known_hosts' '7ae6386df
 rsconf_install_access '700' 'vagrant' 'vagrant'
 rsconf_install_directory '/srv/mpi_worker/user/vagrant/bin'
 rsconf_install_access '500' 'vagrant' 'vagrant'
-rsconf_install_file '/srv/mpi_worker/user/vagrant/bin/rsmpi' '83078a52dd4868e12eb0b3583de85e0d'
+rsconf_install_file '/srv/mpi_worker/user/vagrant/bin/rsmpi' '845d40e77c98a9c05643fa04a095057d'
 rsconf_install_access '700' 'vagrant' 'vagrant'
 rsconf_install_directory '/srv/mpi_worker'
 rsconf_install_access '500' 'vagrant' 'vagrant'

--- a/tests/pkcli/build1_data/1.out/srv/host/v5.radia.run/srv/mpi_worker/user/vagrant/bin/rsmpi
+++ b/tests/pkcli/build1_data/1.out/srv/host/v5.radia.run/srv/mpi_worker/user/vagrant/bin/rsmpi
@@ -221,7 +221,7 @@ rsmpi_ping() {
             -o IdentityFile="$_rsmpi_conf_d/$h"/identity \
             -o StrictHostKeyChecking=no \
             -o UserKnownHostsFile=/dev/null \
-            "$h" hostname 2>/dev/null < /dev/null || true)
+            "$h" 'find /dev/shm -mindepth 1 -delete 2>/dev/null || true; hostname' 2>/dev/null < /dev/null || true)
         if [[ $x == $h ]]; then
             ok+=1
         else


### PR DESCRIPTION
## Summary
- In `rsmpi_ping()`, the SSH command now runs `find /dev/shm -mindepth 1 -delete` before `hostname` on each worker host
- This clears orphaned mpich4 shared memory segments (same issue as radiasoft/sirepo#7741) in one SSH round-trip per host, as part of the existing up-check
