### PR TITLE
Fix #661 add network.trusted_hosts

### DIFF
--- a/rsconf/component/network.py
+++ b/rsconf/component/network.py
@@ -68,11 +68,15 @@ class T(rsconf.component.T):
                 public_tcp_ports=[],
                 public_udp_ports=[],
                 restricted_public_tcp_ports=PKDict,
+                trusted_hosts=[],
                 trusted_tcp_ports=[],
             )
             self.__trusted_nets = self._nets(self.j2_ctx, z.trusted)
             z.pkupdate(
                 blocked_ips=tuple(str(ipaddress.ip_network(n)) for n in z.blocked_ips),
+                trusted_host_ips=tuple(
+                    sorted(socket.gethostbyname(h) for h in z.trusted_hosts)
+                ),
                 trusted_nets=tuple(sorted(z.trusted.keys())),
                 # TODO(robnagler) Generalize this check in db after #548 is merged
                 use_network_scripts=self.hdb.rsconf_db.is_centos7,
@@ -184,6 +188,9 @@ class T(rsconf.component.T):
         for w in "public_tcp_ports", "public_udp_ports", "trusted_tcp_ports":
             # some ports are listed as https and http, and others 9999
             z[w] = sorted([str(p) for p in z[w]])
+        z._trusted_sources = sorted(
+            [str(n) for n in z.trusted_public_nets] + list(z.trusted_host_ips)
+        )
         # Only for jupyterhub, explicitly set, and not on a machine
         # with a public address
         self.install_access(mode="444", owner=self.hdb.rsconf_db.root_u)

--- a/rsconf/package_data/network/iptables.jinja
+++ b/rsconf/package_data/network/iptables.jinja
@@ -33,8 +33,8 @@
     -A INPUT -i {{ network.inet_dev.name }} -p tcp -m state --state NEW -m tcp --match multiport --dports {{ network.public_tcp_ports | join(',') }} -j ACCEPT
 {% endif %}
 {% if network.trusted_tcp_ports %}
-    {% for n in network.trusted_public_nets %}
-        -A INPUT -i {{ network.inet_dev.name }} -s {{ n }} -p tcp -m state --state NEW -m tcp --match multiport --dports {{ network.trusted_tcp_ports | join(',') }} -j ACCEPT
+    {% for s in network._trusted_sources %}
+        -A INPUT -i {{ network.inet_dev.name }} -s {{ s }} -p tcp -m state --state NEW -m tcp --match multiport --dports {{ network.trusted_tcp_ports | join(',') }} -j ACCEPT
     {% endfor %}
 {% endif %}
 {% if network.public_udp_ports %}
@@ -51,9 +51,9 @@
 -A INPUT -i {{ network.inet_dev.name }} -p tcp -m tcp --tcp-option 128 -j REJECT --reject-with icmp-port-unreachable
 
 {# ssh: Accept our networks always #}
-{% for n in network.trusted_public_nets %}
-    {% set s = ([ 22 ] + network.public_ssh_ports)|unique|join(',') %}
-    -A INPUT -i {{ network.inet_dev.name }} -s {{ n }} -p tcp -m tcp --match multiport --dports {{ s }} -j ACCEPT
+{% for s in network._trusted_sources %}
+    {% set ports = ([ 22 ] + network.public_ssh_ports)|unique|join(',') %}
+    -A INPUT -i {{ network.inet_dev.name }} -s {{ s }} -p tcp -m tcp --match multiport --dports {{ ports }} -j ACCEPT
 {% endfor %}
 {% if network.public_ssh_ports %}
     {% set s = '-A INPUT -i ' + network.inet_dev.name + ' -p tcp -m state --state NEW -m tcp --match multiport --dports ' +  (network.public_ssh_ports|join(',')) %}

--- a/tests/pkcli/build1_data/1.in/db/000.yml
+++ b/tests/pkcli/build1_data/1.in/db/000.yml
@@ -521,6 +521,8 @@ host:
           https: [ 192.168.1.0/24, 127.0.0.1 ]
         public_ssh_ports: [ 5555, 6666 ]
         public_tcp_ports: [ 9999 ]
+        trusted_hosts:
+          - redirect1.v.radia.run
         devices:
           em1:
             ip: 10.10.10.5

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/sysconfig/iptables
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/sysconfig/iptables
@@ -17,6 +17,7 @@
 -A INPUT -i em2 -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m state --state NEW -j REJECT --reject-with icmp-port-unreachable
 -A INPUT -i em2 -p tcp -m tcp --tcp-option 128 -j REJECT --reject-with icmp-port-unreachable
 
+    -A INPUT -i em2 -s 10.10.10.10 -p tcp -m tcp --match multiport --dports 22,5555,6666 -j ACCEPT
     -A INPUT -i em2 -s 104.237.137.251/32 -p tcp -m tcp --match multiport --dports 22,5555,6666 -j ACCEPT
     -A INPUT -i em2 -s 216.17.132.32/27 -p tcp -m tcp --match multiport --dports 22,5555,6666 -j ACCEPT
     -A INPUT -i em2 -p tcp -m state --state NEW -m tcp --match multiport --dports 5555,6666 -m recent --set --name SSHPROBES --mask 255.255.255.0 --rsource

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/network.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/network.sh
@@ -7,7 +7,7 @@ rsconf_install_file '/etc/resolv.conf' 'c333a7a816c03062d4e61effd6d2a8ce'
 rsconf_install_file '/etc/sysconfig/network-scripts/ifcfg-em1' 'e225a3f7b4b071e5c204b1182c17ab94'
 rsconf_install_file '/etc/sysconfig/network-scripts/ifcfg-em2' '4f8c01335a3bf1a8a89ba5d09fdf28df'
 rsconf_install_access '444' 'root' 'root'
-rsconf_install_file '/etc/sysconfig/iptables' '422d9959bcaf8e047c266a168ba2638e'
+rsconf_install_file '/etc/sysconfig/iptables' '7d1d05dff818c372c61feae0c79e1ddb'
 network_main
 }
 #!/bin/bash


### PR DESCRIPTION
Adds network.trusted_hosts, a list of hostnames resolved to IPs at build time. The resolved IPs are combined with trusted_public_nets into a single _trusted_sources list in internal_build_write, which iptables.jinja uses for both the trusted TCP ports and SSH accept rules.