### PR TITLE
Fix #687 Fix postgresql log install when old log dir is empty

### DIFF
--- a/rsconf/package_data/logrotate/main.sh.jinja
+++ b/rsconf/package_data/logrotate/main.sh.jinja
@@ -1,5 +1,4 @@
 #!/bin/bash
-shopt -s nullglob
 
 logrotate_main() {
     # We use a systemd timer so can have output in the journal, and not emailed (anacron requires email)
@@ -17,7 +16,8 @@ logrotate_main() {
             's/\brotate/#rotate/'
     fi
     for f in /etc/logrotate.d/*; do
-        if grep --no-messages --quiet ' delaycompress' "$f"; then
+        # without nullglob f could be /etc/logrotate.d/* literal
+        if [[ -f $f ]] && grep --no-messages --quiet ' delaycompress' "$f"; then
             rsconf_edit_no_change_res=0 rsconf_edit "$f" '#delaycompress' \
                's/\bdelaycompress/#delaycompress/'
         fi

--- a/rsconf/package_data/logrotate/main.sh.jinja
+++ b/rsconf/package_data/logrotate/main.sh.jinja
@@ -16,8 +16,7 @@ logrotate_main() {
             's/\brotate/#rotate/'
     fi
     for f in /etc/logrotate.d/*; do
-        # without nullglob f could be /etc/logrotate.d/* literal
-        if [[ -f $f ]] && grep --no-messages --quiet ' delaycompress' "$f"; then
+        if grep --no-messages --quiet ' delaycompress' "$f"; then
             rsconf_edit_no_change_res=0 rsconf_edit "$f" '#delaycompress' \
                's/\bdelaycompress/#delaycompress/'
         fi

--- a/rsconf/package_data/postgresql/main.sh.jinja
+++ b/rsconf/package_data/postgresql/main.sh.jinja
@@ -29,8 +29,11 @@ postgresql_log() {
     if [[ ! -L $old ]]; then
         install -d -m 700 '{{ postgresql.log_d }}'
         # save the old logs, just in case
-        for f in $(ls -tr "$old"/*.log 2>/dev/null || true); do
-            cat $f >> '{{ postgresql.log_f }}'
+        # don't use glob with ls to prevent listing cwd if nullglob and old is missing/empty
+        for f in $(ls -tr "$old" 2>/dev/null || true); do
+            if [[ $f == *.log ]]; then
+                cat "$old/$f" >> '{{ postgresql.log_f }}'
+            fi
         done
         chown -R postgres:postgres '{{ postgresql.log_d }}'
         rm -rf "$old"

--- a/rsconf/package_data/postgresql/main.sh.jinja
+++ b/rsconf/package_data/postgresql/main.sh.jinja
@@ -26,6 +26,9 @@ postgresql_install() {
 
 postgresql_log() {
     local old=/var/lib/pgsql/data/pg_log
+    if [[ '{{ postgresql.log_d }}' == "$old" ]]; then
+        install_err "postgresql.log_d must not be $old, which is replaced with a symlink"
+    fi
     if [[ ! -L $old ]]; then
         install -d -m 700 '{{ postgresql.log_d }}'
         # save the old logs, just in case

--- a/rsconf/package_data/postgresql/main.sh.jinja
+++ b/rsconf/package_data/postgresql/main.sh.jinja
@@ -29,12 +29,7 @@ postgresql_log() {
     if [[ ! -L $old ]]; then
         install -d -m 700 '{{ postgresql.log_d }}'
         # save the old logs, just in case
-        # don't use glob with ls to prevent listing cwd if nullglob and old is missing/empty
-        for f in $(ls -tr "$old" 2>/dev/null || true); do
-            if [[ $f == *.log ]]; then
-                cat "$old/$f" >> '{{ postgresql.log_f }}'
-            fi
-        done
+        cat "$old"/*.log /dev/null >> '{{ postgresql.log_f }}'
         chown -R postgres:postgres '{{ postgresql.log_d }}'
         rm -rf "$old"
         ln -r -s '{{ postgresql.log_d }}' "$old"

--- a/rsconf/package_data/rsconf/rsconf.sh
+++ b/rsconf/package_data/rsconf/rsconf.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+shopt -s nullglob
 
 rsconf_append() {
     declare file=$1

--- a/tests/pkcli/build1_data/1.out/srv/host/v3.radia.run/logrotate.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v3.radia.run/logrotate.sh
@@ -15,7 +15,6 @@ rsconf_install_file '/etc/logrotate.conf' 'c59f3376adf6ef244541b8ae596cc304'
 logrotate_main
 }
 #!/bin/bash
-shopt -s nullglob
 
 logrotate_main() {
     # We use a systemd timer so can have output in the journal, and not emailed (anacron requires email)
@@ -33,7 +32,8 @@ logrotate_main() {
             's/\brotate/#rotate/'
     fi
     for f in /etc/logrotate.d/*; do
-        if grep --no-messages --quiet ' delaycompress' "$f"; then
+        # without nullglob f could be /etc/logrotate.d/* literal
+        if [[ -f $f ]] && grep --no-messages --quiet ' delaycompress' "$f"; then
             rsconf_edit_no_change_res=0 rsconf_edit "$f" '#delaycompress' \
                's/\bdelaycompress/#delaycompress/'
         fi

--- a/tests/pkcli/build1_data/1.out/srv/host/v3.radia.run/logrotate.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v3.radia.run/logrotate.sh
@@ -32,8 +32,7 @@ logrotate_main() {
             's/\brotate/#rotate/'
     fi
     for f in /etc/logrotate.d/*; do
-        # without nullglob f could be /etc/logrotate.d/* literal
-        if [[ -f $f ]] && grep --no-messages --quiet ' delaycompress' "$f"; then
+        if grep --no-messages --quiet ' delaycompress' "$f"; then
             rsconf_edit_no_change_res=0 rsconf_edit "$f" '#delaycompress' \
                's/\bdelaycompress/#delaycompress/'
         fi

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postgresql.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postgresql.sh
@@ -51,12 +51,7 @@ postgresql_log() {
     if [[ ! -L $old ]]; then
         install -d -m 700 '/var/log/postgresql'
         # save the old logs, just in case
-        # don't use glob with ls to prevent listing cwd if nullglob and old is missing/empty
-        for f in $(ls -tr "$old" 2>/dev/null || true); do
-            if [[ $f == *.log ]]; then
-                cat "$old/$f" >> '/var/log/postgresql/postgresql.log'
-            fi
-        done
+        cat "$old"/*.log /dev/null >> '/var/log/postgresql/postgresql.log'
         chown -R postgres:postgres '/var/log/postgresql'
         rm -rf "$old"
         ln -r -s '/var/log/postgresql' "$old"

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postgresql.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postgresql.sh
@@ -48,6 +48,9 @@ postgresql_install() {
 
 postgresql_log() {
     local old=/var/lib/pgsql/data/pg_log
+    if [[ '/var/log/postgresql' == "$old" ]]; then
+        install_err "postgresql.log_d must not be $old, which is replaced with a symlink"
+    fi
     if [[ ! -L $old ]]; then
         install -d -m 700 '/var/log/postgresql'
         # save the old logs, just in case

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postgresql.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postgresql.sh
@@ -51,8 +51,11 @@ postgresql_log() {
     if [[ ! -L $old ]]; then
         install -d -m 700 '/var/log/postgresql'
         # save the old logs, just in case
-        for f in $(ls -tr "$old"/*.log 2>/dev/null || true); do
-            cat $f >> '/var/log/postgresql/postgresql.log'
+        # don't use glob with ls to prevent listing cwd if nullglob and old is missing/empty
+        for f in $(ls -tr "$old" 2>/dev/null || true); do
+            if [[ $f == *.log ]]; then
+                cat "$old/$f" >> '/var/log/postgresql/postgresql.log'
+            fi
         done
         chown -R postgres:postgres '/var/log/postgresql'
         rm -rf "$old"


### PR DESCRIPTION
The existing logic tries to save existing log files, but is insufficient when the assumed old log dir doesn't exist or is empty and the logrotate component is also being installed (the logic for which would come before the postgresql logic).

One or both of the commits here could be employed to handle this issue. Could also just not try to save the old logs, or fix this in another way.