### PR TITLE
Revert "Fix #695 Use unix socket to work around TCP milter processing delays"

### DIFF
--- a/rsconf/component/opendkim.py
+++ b/rsconf/component/opendkim.py
@@ -12,7 +12,6 @@ from rsconf import component
 
 _CONF_D = pkio.py_path("/etc/opendkim")
 _CONF_F = _CONF_D.new(ext=".conf")
-_RUN_D = pkio.py_path("/run/opendkim")
 _SECRET_SUBDIR = "opendkim"
 
 
@@ -21,17 +20,14 @@ class T(component.T):
         jc, z = self.j2_ctx_init()
         self.buildt.require_component("postfix")
         self.append_root_bash("rsconf_yum_install opendkim")
-        z.pksetdefault(smtp_clients=[])
+        z.pksetdefault(port=8891, smtp_clients=[])
         z.update(
             external_ignore_list_f=_CONF_D.join("ExternalIgnoreList"),
             internal_hosts_f=_CONF_D.join("InternalHosts"),
             key_table_f=_CONF_D.join("KeyTable"),
             keys_d=_CONF_D.join("keys"),
-            # postfix connects to socket_f so must be able to write it
-            run_g="postfix",
             run_u="opendkim",
             signing_table_f=_CONF_D.join("SigningTable"),
-            socket_f=_RUN_D.join("opendkim.sock"),
         )
         self._read_keys(jc, z)
         self.buildt.get_component("postfix").setup_opendkim(self)

--- a/rsconf/component/postfix.py
+++ b/rsconf/component/postfix.py
@@ -58,7 +58,7 @@ class T(component.T):
             sasl_host_users=[],
         )
         z.have_sasl = bool(z.get("sasl_users") or z.get("sasl_host_users"))
-        z.opendkim_socket_f = None
+        z.opendkim_port = None
         z.local_host_names = []
         self._setup_mynames(jc, z)
 
@@ -109,7 +109,7 @@ class T(component.T):
 
     def setup_opendkim(self, opendkim):
         z = self.j2_ctx.postfix
-        z.opendkim_socket_f = opendkim.j2_ctx.opendkim.socket_f
+        z.opendkim_port = opendkim.j2_ctx.opendkim.port
 
     def _setup_mynames(self, jc, z):
         jc = self.j2_ctx

--- a/rsconf/package_data/opendkim/opendkim.conf.jinja
+++ b/rsconf/package_data/opendkim/opendkim.conf.jinja
@@ -10,9 +10,9 @@ PidFile /run/opendkim/opendkim.pid
 SendReports no
 SignHeaders Cc,Content-Type,Date,From,In-Reply-To,Message-Id,Mime-Version,References,Reply-To,Subject,To
 SigningTable refile:{{ opendkim.signing_table_f }}
-Socket local:{{ opendkim.socket_f }}
+Socket inet:{{ opendkim.port }}@localhost
 SoftwareHeader no
 Syslog yes
 SyslogSuccess yes
 Umask 007
-UserID {{ opendkim.run_u }}:{{ opendkim.run_g }}
+UserID {{ opendkim.run_u }}:{{ opendkim.run_u }}

--- a/rsconf/package_data/postfix/main.cf.jinja
+++ b/rsconf/package_data/postfix/main.cf.jinja
@@ -92,11 +92,11 @@ smtpd_sender_restrictions =
 {#
     Conditional Custom Config: alphabetical by conditional
 #}
-{% if postfix.opendkim_socket_f %}
+{% if postfix.opendkim_port %}
 milter_default_action = tempfail
 milter_protocol = 2
-smtpd_milters = unix:{{ postfix.opendkim_socket_f }}
-non_smtpd_milters = unix:{{ postfix.opendkim_socket_f }}
+smtpd_milters = inet:localhost:{{ postfix.opendkim_port }}
+non_smtpd_milters = inet:localhost:{{ postfix.opendkim_port }}
 internal_mail_filter_classes = bounce, notify
 {% endif %}
 {% if not postfix.have_public_smtp %}

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/opendkim.conf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/opendkim.conf
@@ -10,9 +10,9 @@ PidFile /run/opendkim/opendkim.pid
 SendReports no
 SignHeaders Cc,Content-Type,Date,From,In-Reply-To,Message-Id,Mime-Version,References,Reply-To,Subject,To
 SigningTable refile:/etc/opendkim/SigningTable
-Socket local:/run/opendkim/opendkim.sock
+Socket inet:8891@localhost
 SoftwareHeader no
 Syslog yes
 SyslogSuccess yes
 Umask 007
-UserID opendkim:postfix
+UserID opendkim:opendkim

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/postfix/main.cf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/postfix/main.cf
@@ -72,8 +72,8 @@ smtpd_sender_restrictions =
     reject_unknown_sender_domain
 milter_default_action = tempfail
 milter_protocol = 2
-smtpd_milters = unix:/run/opendkim/opendkim.sock
-non_smtpd_milters = unix:/run/opendkim/opendkim.sock
+smtpd_milters = inet:localhost:8891
+non_smtpd_milters = inet:localhost:8891
 internal_mail_filter_classes = bounce, notify
 smtpd_tls_security_level = may
 local_recipient_maps =

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postfix.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postfix.sh
@@ -8,7 +8,7 @@ rsconf_install_access '400' 'root' 'root'
 rsconf_install_file '/etc/postfix/v9.radia.run.key' 'fe22a3a98b83d3cd8d48eb5ccda07d60'
 rsconf_install_file '/etc/postfix/v9.radia.run.crt' 'a6d3bba40727a12f03b1f44727bb98be'
 rsconf_install_access '644' 'root' 'root'
-rsconf_install_file '/etc/postfix/main.cf' 'b12a0d7b52644bd9dc7440aed01ecf55'
+rsconf_install_file '/etc/postfix/main.cf' '125732609560668f328d97848dabbd7d'
 rsconf_install_file '/etc/postfix/master.cf' '7963eb585d2f004631f7a78748d4dac7'
 rsconf_install_file '/etc/aliases' '505977dfd514ab835c60dacf40535cd1'
 postfix_main


### PR DESCRIPTION
Reverts radiasoft/rsconf#696 for now due to #697 so that prod releases can go forward. Will reimplement at a later time with changes to address the socket permissions issue. 