### PR TITLE
Fix #695 opendkim unix socket milter

### DIFF
--- a/rsconf/component/opendkim.py
+++ b/rsconf/component/opendkim.py
@@ -12,6 +12,7 @@ from rsconf import component
 
 _CONF_D = pkio.py_path("/etc/opendkim")
 _CONF_F = _CONF_D.new(ext=".conf")
+_RUN_D = pkio.py_path("/run/opendkim")
 _SECRET_SUBDIR = "opendkim"
 
 
@@ -20,14 +21,19 @@ class T(component.T):
         jc, z = self.j2_ctx_init()
         self.buildt.require_component("postfix")
         self.append_root_bash("rsconf_yum_install opendkim")
+        # TODO: remove port config. the milter changed to use a unix socket. Accepted so hosts
+        # that still set it don't fail to build.
         z.pksetdefault(port=8891, smtp_clients=[])
         z.update(
             external_ignore_list_f=_CONF_D.join("ExternalIgnoreList"),
             internal_hosts_f=_CONF_D.join("InternalHosts"),
             key_table_f=_CONF_D.join("KeyTable"),
             keys_d=_CONF_D.join("keys"),
+            # postfix connects to socket_f so must be able to write it
+            run_g="postfix",
             run_u="opendkim",
             signing_table_f=_CONF_D.join("SigningTable"),
+            socket_f=_RUN_D.join("opendkim.sock"),
         )
         self._read_keys(jc, z)
         self.buildt.get_component("postfix").setup_opendkim(self)

--- a/rsconf/component/opendkim.py
+++ b/rsconf/component/opendkim.py
@@ -14,6 +14,7 @@ _CONF_D = pkio.py_path("/etc/opendkim")
 _CONF_F = _CONF_D.new(ext=".conf")
 _RUN_D = pkio.py_path("/run/opendkim")
 _SECRET_SUBDIR = "opendkim"
+_SOCKET_G = "dkimsocket"
 
 
 class T(component.T):
@@ -21,18 +22,21 @@ class T(component.T):
         jc, z = self.j2_ctx_init()
         self.buildt.require_component("postfix")
         self.append_root_bash("rsconf_yum_install opendkim")
-        z.pksetdefault(smtp_clients=[])
+        z.pksetdefault(
+            port=8891,
+            smtp_clients=[],
+            socket_gid=3000,
+            want_unix_socket=False,
+        )
         z.update(
             external_ignore_list_f=_CONF_D.join("ExternalIgnoreList"),
             internal_hosts_f=_CONF_D.join("InternalHosts"),
             key_table_f=_CONF_D.join("KeyTable"),
             keys_d=_CONF_D.join("keys"),
-            # postfix connects to socket_f so must be able to write it
-            run_g="postfix",
             run_u="opendkim",
             signing_table_f=_CONF_D.join("SigningTable"),
-            socket_f=_RUN_D.join("opendkim.sock"),
         )
+        self._setup_socket(z)
         self._read_keys(jc, z)
         self.buildt.get_component("postfix").setup_opendkim(self)
         self._trusted_hosts(jc, z)
@@ -45,6 +49,11 @@ class T(component.T):
         z = jc[self.name]
         systemd.unit_prepare(self, jc, watch_files=(_CONF_D, _CONF_F))
         self._install_conf(jc, z, self._install_keys(jc, z))
+        if z.want_unix_socket:
+            self.append_root_bash_with_main(jc)
+            # the unit sets Group so opendkim starts unprivileged and cannot
+            # honor UserID's group, which is what gives the socket its group
+            systemd.install_unit_override(self, jc)
         systemd.unit_enable(self, jc)
 
     def _install_conf(self, jc, z, key_list):
@@ -123,6 +132,27 @@ class T(component.T):
                 raise AssertionError(f"missing keys for domain={d}")
             for k in v.rows:
                 k.subdomain = opendkim.public_key_info(k.txt_f)
+
+    def _setup_socket(self, z):
+        if not z.want_unix_socket:
+            z.update(
+                milter=f"inet:localhost:{z.port}",
+                run_g=z.run_u,
+                socket=f"inet:{z.port}@localhost",
+                socket_f=None,
+            )
+            return
+        f = _RUN_D.join("opendkim.sock")
+        # f is created with run_g so socket_client_u can connect to it. A group
+        # of its own keeps socket_client_u out of the group that owns keys_d,
+        # and run_u out of the group that owns the postfix queue.
+        z.update(
+            milter=f"unix:{f}",
+            run_g=_SOCKET_G,
+            socket=f"local:{f}",
+            socket_client_u="postfix",
+            socket_f=f,
+        )
 
     def _trusted_hosts(self, jc, z):
         from rsconf import db

--- a/rsconf/component/opendkim.py
+++ b/rsconf/component/opendkim.py
@@ -21,9 +21,7 @@ class T(component.T):
         jc, z = self.j2_ctx_init()
         self.buildt.require_component("postfix")
         self.append_root_bash("rsconf_yum_install opendkim")
-        # TODO: remove port config. the milter changed to use a unix socket. Accepted so hosts
-        # that still set it don't fail to build.
-        z.pksetdefault(port=8891, smtp_clients=[])
+        z.pksetdefault(smtp_clients=[])
         z.update(
             external_ignore_list_f=_CONF_D.join("ExternalIgnoreList"),
             internal_hosts_f=_CONF_D.join("InternalHosts"),

--- a/rsconf/component/postfix.py
+++ b/rsconf/component/postfix.py
@@ -58,7 +58,7 @@ class T(component.T):
             sasl_host_users=[],
         )
         z.have_sasl = bool(z.get("sasl_users") or z.get("sasl_host_users"))
-        z.opendkim_socket_f = None
+        z.opendkim_milter = None
         z.local_host_names = []
         self._setup_mynames(jc, z)
 
@@ -109,7 +109,7 @@ class T(component.T):
 
     def setup_opendkim(self, opendkim):
         z = self.j2_ctx.postfix
-        z.opendkim_socket_f = opendkim.j2_ctx.opendkim.socket_f
+        z.opendkim_milter = opendkim.j2_ctx.opendkim.milter
 
     def _setup_mynames(self, jc, z):
         jc = self.j2_ctx

--- a/rsconf/component/postfix.py
+++ b/rsconf/component/postfix.py
@@ -58,7 +58,7 @@ class T(component.T):
             sasl_host_users=[],
         )
         z.have_sasl = bool(z.get("sasl_users") or z.get("sasl_host_users"))
-        z.opendkim_port = None
+        z.opendkim_socket_f = None
         z.local_host_names = []
         self._setup_mynames(jc, z)
 
@@ -109,7 +109,7 @@ class T(component.T):
 
     def setup_opendkim(self, opendkim):
         z = self.j2_ctx.postfix
-        z.opendkim_port = opendkim.j2_ctx.opendkim.port
+        z.opendkim_socket_f = opendkim.j2_ctx.opendkim.socket_f
 
     def _setup_mynames(self, jc, z):
         jc = self.j2_ctx

--- a/rsconf/package_data/opendkim/main.sh.jinja
+++ b/rsconf/package_data/opendkim/main.sh.jinja
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+opendkim_main() {
+    rsconf_group '{{ opendkim.run_g }}' '{{ opendkim.socket_gid }}'
+    if id -nG '{{ opendkim.socket_client_u }}' \
+        | grep -F -q -w -- '{{ opendkim.run_g }}'; then
+        return
+    fi
+    usermod --append --groups '{{ opendkim.run_g }}' '{{ opendkim.socket_client_u }}'
+    # supplementary groups are read at startup so the running master and the
+    # cleanup daemons it forks do not have the new group
+    rsconf_service_trigger_restart postfix
+}

--- a/rsconf/package_data/opendkim/opendkim.conf.jinja
+++ b/rsconf/package_data/opendkim/opendkim.conf.jinja
@@ -10,7 +10,7 @@ PidFile /run/opendkim/opendkim.pid
 SendReports no
 SignHeaders Cc,Content-Type,Date,From,In-Reply-To,Message-Id,Mime-Version,References,Reply-To,Subject,To
 SigningTable refile:{{ opendkim.signing_table_f }}
-Socket local:{{ opendkim.socket_f }}
+Socket {{ opendkim.socket }}
 SoftwareHeader no
 Syslog yes
 SyslogSuccess yes

--- a/rsconf/package_data/opendkim/opendkim.conf.jinja
+++ b/rsconf/package_data/opendkim/opendkim.conf.jinja
@@ -10,9 +10,9 @@ PidFile /run/opendkim/opendkim.pid
 SendReports no
 SignHeaders Cc,Content-Type,Date,From,In-Reply-To,Message-Id,Mime-Version,References,Reply-To,Subject,To
 SigningTable refile:{{ opendkim.signing_table_f }}
-Socket inet:{{ opendkim.port }}@localhost
+Socket local:{{ opendkim.socket_f }}
 SoftwareHeader no
 Syslog yes
 SyslogSuccess yes
 Umask 007
-UserID {{ opendkim.run_u }}:{{ opendkim.run_u }}
+UserID {{ opendkim.run_u }}:{{ opendkim.run_g }}

--- a/rsconf/package_data/opendkim/unit_override.conf.jinja
+++ b/rsconf/package_data/opendkim/unit_override.conf.jinja
@@ -1,0 +1,2 @@
+[Service]
+Group={{ opendkim.run_g }}

--- a/rsconf/package_data/postfix/main.cf.jinja
+++ b/rsconf/package_data/postfix/main.cf.jinja
@@ -92,11 +92,11 @@ smtpd_sender_restrictions =
 {#
     Conditional Custom Config: alphabetical by conditional
 #}
-{% if postfix.opendkim_socket_f %}
+{% if postfix.opendkim_milter %}
 milter_default_action = tempfail
 milter_protocol = 2
-smtpd_milters = unix:{{ postfix.opendkim_socket_f }}
-non_smtpd_milters = unix:{{ postfix.opendkim_socket_f }}
+smtpd_milters = {{ postfix.opendkim_milter }}
+non_smtpd_milters = {{ postfix.opendkim_milter }}
 internal_mail_filter_classes = bounce, notify
 {% endif %}
 {% if not postfix.have_public_smtp %}

--- a/rsconf/package_data/postfix/main.cf.jinja
+++ b/rsconf/package_data/postfix/main.cf.jinja
@@ -92,11 +92,11 @@ smtpd_sender_restrictions =
 {#
     Conditional Custom Config: alphabetical by conditional
 #}
-{% if postfix.opendkim_port %}
+{% if postfix.opendkim_socket_f %}
 milter_default_action = tempfail
 milter_protocol = 2
-smtpd_milters = inet:localhost:{{ postfix.opendkim_port }}
-non_smtpd_milters = inet:localhost:{{ postfix.opendkim_port }}
+smtpd_milters = unix:{{ postfix.opendkim_socket_f }}
+non_smtpd_milters = unix:{{ postfix.opendkim_socket_f }}
 internal_mail_filter_classes = bounce, notify
 {% endif %}
 {% if not postfix.have_public_smtp %}

--- a/rsconf/package_data/rsconf/rsconf.sh
+++ b/rsconf/package_data/rsconf/rsconf.sh
@@ -139,12 +139,12 @@ rsconf_group() {
         fi
         return
     fi
-    declare flags=()
+    declare system_flag=
     #POSIT: <1000 is system
-        flags+=( -r )
     if (( gid < 1000 )); then
+        system_flag=-r
     fi
-    groupadd "${flags[@]}" -g "$gid" "$group"
+    groupadd $system_flag -g "$gid" "$group"
 }
 
 rsconf_install_access() {

--- a/rsconf/package_data/rsconf/rsconf.sh
+++ b/rsconf/package_data/rsconf/rsconf.sh
@@ -141,8 +141,8 @@ rsconf_group() {
     fi
     declare flags=()
     #POSIT: <1000 is system
-    if [[ $gid < 1000 ]]; then
         flags+=( -r )
+    if (( gid < 1000 )); then
     fi
     groupadd "${flags[@]}" -g "$gid" "$group"
 }

--- a/rsconf/package_data/rsconf/rsconf.sh
+++ b/rsconf/package_data/rsconf/rsconf.sh
@@ -640,25 +640,6 @@ rsconf_systemctl_clean_unit() {
     rm -f "/etc/systemd/system/$basename$x.service"
 }
 
-rsconf_user() {
-    declare user=$1
-    declare uid=$2
-    declare exist_uid=$(id -u "$user" 2>/dev/null || true)
-    rsconf_group "$user" "$gid"
-    if [[ $exist_uid ]]; then
-        if [[ $exist_uid != $uid ]]; then
-            install_err "$exist_uid: unexpected uid (expect=$uid) for user $user"
-        fi
-        return
-    fi
-    declare flags=()
-    #POSIT: <1000 is system
-    if [[ $gid < 1000 ]]; then
-        flags+=( -r )
-    fi
-    useradd "${flags[@]}" -g "$user" -u "$uid" "$user"
-}
-
 rsconf_yum_install() {
     declare x todo=()
     for x in "$@"; do

--- a/tests/pkcli/build1_data/1.in/db/000.yml
+++ b/tests/pkcli/build1_data/1.in/db/000.yml
@@ -368,7 +368,7 @@ host:
         #components: [ rsconf, docker_registry, btest ]
 #        components: [ bop ]
         #components: [ bkp, jupyterhub, jupyterhub_proxy ]
-        components: [ postfix, nfs_server, sirepo, script ]
+        components: [ postfix, nfs_server, opendkim, sirepo, script ]
       script:
         rsconf_bash: |
           echo hello
@@ -549,6 +549,7 @@ host:
           /exports/foo: [ 10.10.10.0/24, localhost ]
       opendkim:
         smtp_clients: [ v4.radia.run ]
+        want_unix_socket: true
       postfix:
         postfix_base():
         # if you do not set this, you'll get to test the SLD matching:

--- a/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/000.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/000.sh
@@ -9,6 +9,7 @@ rsconf_require postgrey
 rsconf_require spamd
 rsconf_require postfix
 rsconf_require nfs_server
+rsconf_require opendkim
 rsconf_require db_bkp
 rsconf_require docker
 rsconf_require nginx

--- a/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/etc/opendkim.conf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/etc/opendkim.conf
@@ -10,9 +10,9 @@ PidFile /run/opendkim/opendkim.pid
 SendReports no
 SignHeaders Cc,Content-Type,Date,From,In-Reply-To,Message-Id,Mime-Version,References,Reply-To,Subject,To
 SigningTable refile:/etc/opendkim/SigningTable
-Socket local:/run/opendkim/opendkim.sock
+Socket inet:8891@localhost
 SoftwareHeader no
 Syslog yes
 SyslogSuccess yes
 Umask 007
-UserID opendkim:dkimsocket
+UserID opendkim:opendkim

--- a/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/etc/postfix/main.cf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/etc/postfix/main.cf
@@ -70,6 +70,11 @@ smtpd_sender_restrictions =
     check_sender_access texthash:/etc/postfix/sender_access,
     reject_non_fqdn_sender,
     reject_unknown_sender_domain
+milter_default_action = tempfail
+milter_protocol = 2
+smtpd_milters = inet:localhost:8891
+non_smtpd_milters = inet:localhost:8891
+internal_mail_filter_classes = bounce, notify
 smtpd_tls_security_level = may
 smtpd_delay_reject = yes
 smtpd_sasl_path = smtpd-sasldb

--- a/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/postfix.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v4.radia.run/postfix.sh
@@ -13,7 +13,7 @@ rsconf_install_access '400' 'root' 'root'
 rsconf_install_file '/etc/postfix/star.v4.radia.run.key' '031805b0a7c2e0fd1330b0613f385ede'
 rsconf_install_file '/etc/postfix/star.v4.radia.run.crt' '19cdea6247d259c6ffb2b36726ea297c'
 rsconf_install_access '644' 'root' 'root'
-rsconf_install_file '/etc/postfix/main.cf' 'd1bb3ec199724d930dbcc617f799ebea'
+rsconf_install_file '/etc/postfix/main.cf' '81882e28dc5b21687a0ea7ab7fef490d'
 rsconf_install_file '/etc/postfix/master.cf' '0a14355ea1a1ae57497775949f308c1b'
 rsconf_install_file '/etc/aliases' '014c8aa0c7b0a320bb594911a1b4c908'
 postfix_main

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/opendkim.conf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/opendkim.conf
@@ -10,9 +10,9 @@ PidFile /run/opendkim/opendkim.pid
 SendReports no
 SignHeaders Cc,Content-Type,Date,From,In-Reply-To,Message-Id,Mime-Version,References,Reply-To,Subject,To
 SigningTable refile:/etc/opendkim/SigningTable
-Socket inet:8891@localhost
+Socket local:/run/opendkim/opendkim.sock
 SoftwareHeader no
 Syslog yes
 SyslogSuccess yes
 Umask 007
-UserID opendkim:opendkim
+UserID opendkim:postfix

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/postfix/main.cf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/postfix/main.cf
@@ -72,8 +72,8 @@ smtpd_sender_restrictions =
     reject_unknown_sender_domain
 milter_default_action = tempfail
 milter_protocol = 2
-smtpd_milters = inet:localhost:8891
-non_smtpd_milters = inet:localhost:8891
+smtpd_milters = unix:/run/opendkim/opendkim.sock
+non_smtpd_milters = unix:/run/opendkim/opendkim.sock
 internal_mail_filter_classes = bounce, notify
 smtpd_tls_security_level = may
 local_recipient_maps =

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/systemd/system/opendkim.service.d/99-rsconf.conf
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/etc/systemd/system/opendkim.service.d/99-rsconf.conf
@@ -1,0 +1,2 @@
+[Service]
+Group=dkimsocket

--- a/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postfix.sh
+++ b/tests/pkcli/build1_data/1.out/srv/host/v9.radia.run/postfix.sh
@@ -8,7 +8,7 @@ rsconf_install_access '400' 'root' 'root'
 rsconf_install_file '/etc/postfix/v9.radia.run.key' 'fe22a3a98b83d3cd8d48eb5ccda07d60'
 rsconf_install_file '/etc/postfix/v9.radia.run.crt' 'a6d3bba40727a12f03b1f44727bb98be'
 rsconf_install_access '644' 'root' 'root'
-rsconf_install_file '/etc/postfix/main.cf' '125732609560668f328d97848dabbd7d'
+rsconf_install_file '/etc/postfix/main.cf' 'b12a0d7b52644bd9dc7440aed01ecf55'
 rsconf_install_file '/etc/postfix/master.cf' '7963eb585d2f004631f7a78748d4dac7'
 rsconf_install_file '/etc/aliases' '505977dfd514ab835c60dacf40535cd1'
 postfix_main


### PR DESCRIPTION
Behind feature flag so hosts opt-in to using a unix socket for the opendkim postfix milter. Socket uses `dkimsocket` group, to which `postfix` is added and `opendkim` unit is run with.

Planning to review changes again, so PR is still draft status.